### PR TITLE
Fixed ascii string detection on architectures with unsigned char

### DIFF
--- a/src/psl.c
+++ b/src/psl.c
@@ -479,7 +479,7 @@ const char *psl_registrable_domain(const psl_ctx_t *psl, const char *domain)
 
 static int _str_is_ascii(const char *s)
 {
-	while (*s > 0) s++;
+	while (*s > 0 && *s < 128) s++;
 
 	return !*s;
 }


### PR DESCRIPTION
This pull request resolves issue #13
