### PR TITLE
Allow custom public suffix file

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,3 +1,3 @@
 filesdir = $(datadir)/@PACKAGE@
-files_DATA = effective_tld_names.dat test_psl.txt
+files_DATA = $(PSL_FILE) test_psl.txt
 EXTRA_DIST = $(files_DATA)


### PR DESCRIPTION
There is an option already in the configure.ac to allow system-wide public suffix, Fedora ships the dat as a package "publicsuffix-list" and install it to /usr/share/. Thus I'd like to use the system one since it's updated often.