### PR TITLE
Make sure make_dafsa.py uses Python2

### DIFF
--- a/src/make_dafsa.py
+++ b/src/make_dafsa.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE.chromium file.


### PR DESCRIPTION
make_dafsa.py is a definitely a Python 2 script. On systems where python is symlinked to python3, this script fails causing the build process to fail.