### PR TITLE
Use proper library path and libs for ICU

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,5 @@ script:
   - ./configure --enable-runtime=$RUNTIME --enable-builtin=libidn2 && make clean && make -j4 && make check -j4
   - ./configure --enable-runtime=$RUNTIME --enable-builtin=libidn && make clean && make -j4 && make check -j4
   - ./configure --enable-runtime=$RUNTIME --disable-builtin && make clean && make -j4 && make check -j4
-  - ./configure --enable-gtk-doc && make -j4 && make check -j4
+  - ./configure --enable-gtk-doc && make -j4 V=1 && make check -j4 V=1
   - make distcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ addons:
 
 script:
   - ./autogen.sh
-  - ./configure && make -j4 && make check -j4
+  - ./configure --enable-gtk-doc && grep LIBICU src/Makefile && make -j4 V=1 && make check -j4 V=1
   - ./configure --enable-runtime=$RUNTIME --enable-builtin=libicu && make clean && make -j4 && make check -j4
   - ./configure --enable-runtime=$RUNTIME --enable-builtin=libidn2 && make clean && make -j4 && make check -j4
   - ./configure --enable-runtime=$RUNTIME --enable-builtin=libidn && make clean && make -j4 && make check -j4

--- a/configure.ac
+++ b/configure.ac
@@ -158,9 +158,6 @@ if test "$enable_runtime" = "libicu" -o "$enable_builtin" = "libicu"; then
   PKG_CHECK_MODULES([LIBICU], [icu-uc], [
     HAVE_LIBICU=yes
     if test "$enable_runtime" = "libicu"; then
-      if test "x$LIBICU_LIBS" = "x"; then
-        LIBICU_LIBS="-licuuc"
-      fi
       CFLAGS="$LIBICU_CFLAGS $CFLAGS"
     fi
   ], [

--- a/configure.ac
+++ b/configure.ac
@@ -158,6 +158,9 @@ if test "$enable_runtime" = "libicu" -o "$enable_builtin" = "libicu"; then
   PKG_CHECK_MODULES([LIBICU], [icu-uc], [
     HAVE_LIBICU=yes
     if test "$enable_runtime" = "libicu"; then
+      if test "x$LIBICU_LIBS" = "x"; then
+        LIBICU_LIBS="-licuuc"
+      fi
       CFLAGS="$LIBICU_CFLAGS $CFLAGS"
     fi
   ], [

--- a/configure.ac
+++ b/configure.ac
@@ -171,7 +171,7 @@ if test "$enable_runtime" = "libicu" -o "$enable_builtin" = "libicu"; then
       [AC_LANG_PROGRAM(
         [[#include <unicode/ustring.h>]],
         [[u_strToUTF8(NULL, 0, NULL, NULL, 0, NULL);]])],
-      [HAVE_LIBICU=yes; AC_MSG_RESULT([yes])],
+      [HAVE_LIBICU=yes; LIBICU_LIBS="-licuuc"; AC_MSG_RESULT([yes])],
       [AC_MSG_RESULT([no]); AC_MSG_ERROR(You requested libicu but it is not installed.)])
     LIBS=$OLDLIBS
   ])

--- a/configure.ac
+++ b/configure.ac
@@ -287,3 +287,4 @@ AC_MSG_NOTICE([Summary of build options:
   PSL Test File:     ${PSL_TESTFILE}
   Tests:             ${TESTS_INFO}
 ])
+# Test

--- a/configure.ac
+++ b/configure.ac
@@ -287,4 +287,4 @@ AC_MSG_NOTICE([Summary of build options:
   PSL Test File:     ${PSL_TESTFILE}
   Tests:             ${TESTS_INFO}
 ])
-# Test
+# Test again

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,7 +11,7 @@ libpsl_la_CPPFLAGS = -I$(top_srcdir)/include
 # include ABI version information
 libpsl_la_LDFLAGS = -version-info $(LIBPSL_SO_VERSION)
 if WITH_LIBICU
-  libpsl_la_LDFLAGS += -licuuc
+  libpsl_la_LDFLAGS += $(LIBICU_LIBS)
 endif
 if WITH_LIBIDN2
   libpsl_la_LDFLAGS += -lidn2 -lunistring
@@ -24,7 +24,7 @@ noinst_PROGRAMS = psl2c
 psl2c_SOURCES = psl2c.c lookup_string_in_fixed_set.c
 psl2c_CPPFLAGS = -I$(top_srcdir)/include -DMAKE_DAFSA=\"$(top_srcdir)/src/psl-make-dafsa\"
 if BUILTIN_GENERATOR_LIBICU
-  psl2c_LDADD = -licuuc
+  psl2c_LDADD = $(LIBICU_LIBS)
 endif
 if BUILTIN_GENERATOR_LIBIDN2
   psl2c_LDADD = @LTLIBICONV@ -lidn2 -lunistring


### PR DESCRIPTION
In my environment I have `libicuuc.so` in `/usr/lib` and the ICU pkgconfig files correctly
lists `-L/opt/csw/lib -licuuc`. If only the library is added the wrong SONAME ends up in the binary.