### PR TITLE
Change src/psl-make-dafsa shebang so it'll run on OS X

### DIFF
--- a/src/psl-make-dafsa
+++ b/src/psl-make-dafsa
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Copyright 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE.chromium file.


### PR DESCRIPTION
OS X doesn't follow [PEP 394](https://www.python.org/dev/peps/pep-0394/) and thus it doesn't have a `python2` binary. However, `python` is always Python 2 on OS X, and should be new enough to run `psl-make-dafsa` on the last five or so releases of OS X.

If this would break compatibility with other non-PEP-394 systems where `python` might be Python 3, another alternative might be to use `python2.7` specifically.