### PR TITLE
s/Publix/Public/

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Libpsl...
 - is thread-safe
 - handles IDNA2008 UTS#46 (if libicu is available)
 
-Find more information about the Publix Suffix List [here](https://publicsuffix.org/).
+Find more information about the Public Suffix List [here](https://publicsuffix.org/).
 
 Download the Public Suffix List [here](https://hg.mozilla.org/mozilla-central/raw-file/tip/netwerk/dns/effective_tld_names.dat).
 

--- a/libpsl.pc.in
+++ b/libpsl.pc.in
@@ -4,7 +4,7 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: @PACKAGE_NAME@
-Description: Publix Suffix List C library.
+Description: Public Suffix List C library.
 Version: @PACKAGE_VERSION@
 URL: @PACKAGE_URL@
 Libs: -L${libdir} -lpsl

--- a/tests/test-is-public-all.c
+++ b/tests/test-is-public-all.c
@@ -94,7 +94,7 @@ static void test_psl_entry(const psl_ctx_t *psl, const char *domain, int type)
 		} else ok++;
 
 		if (!(strchr(domain, '.'))) {
-			/* TLDs are always expected to be Publix Suffixes */
+			/* TLDs are always expected to be Public Suffixes */
 			if (!(result = psl_is_public_suffix2(psl, domain, PSL_TYPE_PRIVATE))) {
 				failed++;
 				printf("psl_is_public_suffix2(%s, PSL_TYPE_PRIVATE)=%d (expected 1)\n", domain, result);


### PR DESCRIPTION
Note that the project description on GitHub also contained the typo "Publix" that needs a manual fix.

This supersedes #74.