### PR TITLE
Add new function psl_free_string()

### DIFF
--- a/include/libpsl.h.in
+++ b/include/libpsl.h.in
@@ -79,6 +79,10 @@ typedef struct _psl_ctx_st psl_ctx_t;
 void
 	psl_free(psl_ctx_t *psl);
 
+/* frees memory allocated by libpsl routines */
+void
+	psl_free_string(char *str);
+
 /* loads PSL data from file */
 psl_ctx_t *
 	psl_load_file(const char *fname);

--- a/src/psl.c
+++ b/src/psl.c
@@ -1614,6 +1614,21 @@ int psl_is_cookie_domain_acceptable(const psl_ctx_t *psl, const char *hostname, 
 }
 
 /**
+ * psl_free_string:
+ * @str: pointer to lowercase string returned by psl_str_to_utf8lower()
+ *
+ * This function free()'s the memory allocated by psl_str_to_utf8lower() when
+ * returning a lowercase string
+ *
+ * Since: 0.19
+ */
+void psl_free_string(char *str)
+{
+	if (str)
+		free(str);
+}
+
+/**
  * psl_str_to_utf8lower:
  * @str: string to convert
  * @encoding: charset encoding of @str, e.g. 'iso-8859-1' or %NULL

--- a/tests/test-is-public.c
+++ b/tests/test-is-public.c
@@ -133,16 +133,16 @@ static void test_psl(void)
 		char *lower = NULL;
 
 		psl_str_to_utf8lower("www.example.com", NULL, "de", &lower);
-		free(lower); lower = NULL;
+		psl_free_string(lower); lower = NULL;
 
 		psl_str_to_utf8lower("\374bel.de", NULL, "de", &lower);
-		free(lower); lower = NULL;
+		psl_free_string(lower); lower = NULL;
 
 		psl_str_to_utf8lower("\374bel.de", "iso-8859-1", NULL, &lower);
-		free(lower); lower = NULL;
+		psl_free_string(lower); lower = NULL;
 
 		psl_str_to_utf8lower(NULL, "utf-8", "en", &lower);
-		free(lower); lower = NULL;
+		psl_free_string(lower); lower = NULL;
 	}
 
 	psl_get_version();

--- a/tests/test-registrable-domain.c
+++ b/tests/test-registrable-domain.c
@@ -81,7 +81,7 @@ static void testx(const psl_ctx_t *psl, const char *domain, const char *encoding
 			   domain ? domain : "NULL", result ? result : "NULL", expected_result ? expected_result : "NULL");
 	}
 
-	free(lower);
+	psl_free_string(lower);
 }
 
 static void test(const psl_ctx_t *psl, const char *domain, const char *expected_result)

--- a/tools/psl.c
+++ b/tools/psl.c
@@ -182,7 +182,7 @@ int main(int argc, const char *const *argv)
 				}
 
 				if (rc == PSL_SUCCESS)
-					free(lower);
+					psl_free_string(lower);
 			}
 
 			psl_free(psl);


### PR DESCRIPTION
When writing a wrapper around LibPSL in a different language it is
important that libpsl provide functions to free any memory that it
allocates. Without this, it is impossible to correctly free the memory
allocated by psl_str_to_utf8lower() function since in other languages
one may not have access to the same free() call from libc.