### PR TITLE
Expand defintion of PSL; add ICANN reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Solaris OpenCSW [![Build Status Solaris amd64](https://buildfarm.opencsw.org/bui
 libpsl - C library to handle the Public Suffix List
 ===================================================
 
-A *Public Suffix List* is a collection of *[Brand Top Level Domains](https://icannwiki.org/Brand_TLD)* which allows users to register their own top level domain. The brand domains exist at the same level as ICANN's *Global Top Level Domains (gTLDs)*. Brand TLDs are sometimes referred to as Vanity Domains.
+A *Public Suffix List* is a collection of Top Level Domains (TLDs) suffixes. TLDs include *Global Top Level Domains* (gTLDs) like `.com` and `.net`; *Country Top Level Domains* (ccTLDs) like `.de` and `.cn`; and *[Brand Top Level Domains](https://icannwiki.org/Brand_TLD)* like `.apple` and `.google`. Brand TLDs allows users to register their own top level domain that exist at the same level as ICANN's gTLDs. Brand TLDs are sometimes referred to as Vanity Domains.
 
 Browsers, web clients and other user agents can use a public suffix list to:
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Solaris OpenCSW [![Build Status Solaris amd64](https://buildfarm.opencsw.org/bui
 libpsl - C library to handle the Public Suffix List
 ===================================================
 
-A "public suffix" is a domain name under which Internet users can directly register own names.
+A *Public Suffix List* is a collection of *[Brand Top Level Domains](https://icannwiki.org/Brand_TLD)* which allows users to register their own top level domain. The brand domains exist at the same level as ICANN's *Global Top Level Domains (gTLDs)*. Brand TLDs are sometimes referred to as Vanity Domains.
 
-Browsers and other web clients can use it to
+Browsers, web clients and other user agents can use a public suffix list to:
 
 - avoid privacy-leaking "supercookies"
 - avoid privacy-leaking "super domain" certificates ([see post from Jeffry Walton](https://lists.gnu.org/archive/html/bug-wget/2014-03/msg00093.html))


### PR DESCRIPTION
This commit expands the first paragraph of the README, which explains what a Public Suffix List is. It also introduces ICANN's official name of Brand TLDs, and adds a reference to ICANN's wiki on the Brand TLDs.
  
Sorry about the two commits on this PR. I don't know how to ask Git to squash them from my side of the equation. I tried to [reset the fork](https://stackoverflow.com/questions/9646167/clean-up-a-fork-and-restart-it-from-the-upstream) but the roll-up commit was rejected (maybe due to earlier pr).