### PR TITLE
Fix non-srcdir builds

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,7 @@ CLEANFILES = suffixes_dafsa.c
 lib_LTLIBRARIES = libpsl.la
 
 libpsl_la_SOURCES = psl.c lookup_string_in_fixed_set.c
-libpsl_la_CPPFLAGS = -I$(top_srcdir)/include -DPSL_DISTFILE=\"$(PSL_DISTFILE)\"
+libpsl_la_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include -DPSL_DISTFILE=\"$(PSL_DISTFILE)\"
 # include ABI version information
 libpsl_la_LDFLAGS = -version-info $(LIBPSL_SO_VERSION)
 if WITH_LIBICU

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,7 +1,7 @@
 bin_PROGRAMS = psl
 
-AM_CPPFLAGS = -I$(top_srcdir)/include
-LDADD = ../src/libpsl.la
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include
+LDADD = $(top_builddir)/src/libpsl.la
 
 #if WITH_LIBICU
 #  LDADD += -licuuc


### PR DESCRIPTION
We need to modify the various paths we reference to include the build
directory, in the case when the build directory is not the source
directory.