### PR TITLE
Make code buildable on native Windows (Win32)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,25 +122,48 @@ AC_ARG_ENABLE([asan],
 AC_SUBST([LIBPSL_SO_VERSION], [8:0:3])
 AC_SUBST([LIBPSL_VERSION], $VERSION)
 
+#
+# Check for Win32
+#
+
+AC_MSG_CHECKING([for Win32])
+case "$host" in
+  *-*-mingw*)
+    os_win32=yes
+    ;;
+  *)
+    os_win32=no
+    ;;
+esac
+AC_MSG_RESULT([$os_win32])
+AM_CONDITIONAL(OS_WIN32, [test $os_win32 = yes])
+
+# Windows does not have langinfo.h, which the libidn/libidn2
+# builtin and runtime need, so default to ICU
+if test "x$os_win32" = "xyes" ; then
+  default_runtime=libicu
+  default_builtin=libicu
+else
+  default_runtime=libidn2
+  default_builtin=libidn2
+fi
+
 # Check for enable/disable builtin PSL data
 AC_ARG_ENABLE(runtime,
   [
   --enable-runtime[[=IDNA library]]
       Specify the IDNA library used for libpsl run-time conversions:
-        libidn2 [[default]]: IDNA2008 library (also needs libunistring)
-        libicu:            IDNA2008 UTS#46 library
-        libidn:            IDNA2003 library (also needs libunistring)
+        libidn2 [[default on non-Windows]]: IDNA2008 library (also needs libunistring)
+        libicu [[default on Windows]]:      IDNA2008 UTS#46 library
+        libidn:                           IDNA2003 library (also needs libunistring)
   --disable-runtime        Do not link runtime IDNA functionality
   ], [
     if test "$enableval" = "libidn2" -o "$enableval" = "yes"; then
       enable_runtime=libidn2
-      AC_DEFINE([WITH_LIBIDN2], [1], [generate PSL data using libidn2])
     elif test "$enableval" = "libicu"; then
       enable_runtime=libicu
-      AC_DEFINE([WITH_LIBICU], [1], [generate PSL data using libicu])
     elif test "$enableval" = "libidn"; then
       enable_runtime=libidn
-      AC_DEFINE([WITH_LIBIDN], [1], [generate PSL data using libidn])
     elif test "$enableval" = "no"; then
       enable_runtime=no
     else
@@ -148,8 +171,7 @@ AC_ARG_ENABLE(runtime,
     fi
   ], [
     # this is the default if neither --enable-runtime nor --disable-runtime were specified
-    enable_runtime=libidn2
-    AC_DEFINE([WITH_LIBIDN2], [1], [generate PSL data using libidn2])
+    enable_runtime=$default_runtime
   ])
 
 # Check for enable/disable builtin PSL data
@@ -157,20 +179,17 @@ AC_ARG_ENABLE(builtin,
   [
   --enable-builtin[[=IDNA library]]
       Specify the IDNA library used for built-in data generation:
-        libidn2 [[default]]: IDNA2008 library (also needs libunistring)
-        libicu: IDNA2008   UTS#46 library
-        libidn:            IDNA2003 library (also needs libunistring)
+        libidn2 [[default on non-Windows]]: IDNA2008 library (also needs libunistring)
+        libicu: [[default on Windows]]:     IDNA2008 UTS#46 library
+        libidn:                           IDNA2003 library (also needs libunistring)
   --disable-builtin        Do not generate built-in PSL data
   ], [
     if test "$enableval" = "libidn2" -o "$enableval" = "yes"; then
       enable_builtin=libidn2
-      AC_DEFINE([BUILTIN_GENERATOR_LIBIDN2], [1], [generate PSL data using libidn2])
     elif test "$enableval" = "libicu"; then
       enable_builtin=libicu
-      AC_DEFINE([BUILTIN_GENERATOR_LIBICU], [1], [generate PSL data using libicu])
     elif test "$enableval" = "libidn"; then
       enable_builtin=libidn
-      AC_DEFINE([BUILTIN_GENERATOR_LIBIDN], [1], [generate PSL data using libidn])
     elif test "$enableval" = "no"; then
       enable_builtin=no
     else
@@ -178,8 +197,7 @@ AC_ARG_ENABLE(builtin,
     fi
   ], [
     # this is the default if neither --enable-builtin nor --disable-builtin were specified
-    enable_builtin=libidn2
-    AC_DEFINE([BUILTIN_GENERATOR_LIBIDN2], [1], [generate PSL data using libidn2])
+    enable_builtin=$default_builtin
   ])
 
 if test "$enable_runtime" = "libicu" -o "$enable_builtin" = "libicu"; then
@@ -205,6 +223,15 @@ if test "$enable_runtime" = "libicu" -o "$enable_builtin" = "libicu"; then
   ])
 fi
 
+if test "x$HAVE_LIBICU" = "xyes" ; then
+  if test "$enable_runtime" = "libicu" ; then
+    AC_DEFINE([WITH_LIBICU], [1], [generate PSL data using libicu])
+  fi
+  if test "$enable_builtin" = "libicu" ; then
+    AC_DEFINE([BUILTIN_GENERATOR_LIBICU], [1], [generate PSL data using libicu])
+  fi
+fi
+
 if test "$enable_runtime" = "libidn2" -o "$enable_builtin" = "libidn2"; then
   # Check for libidn2
   PKG_CHECK_MODULES([LIBIDN2], [libidn2], [
@@ -219,6 +246,15 @@ if test "$enable_runtime" = "libidn2" -o "$enable_builtin" = "libidn2"; then
   ])
 fi
 
+if test "x$HAVE_LIBIDN2" = "xyes" ; then
+  if test "$enable_runtime" = "libidn2" ; then
+    AC_DEFINE([WITH_LIBIDN2], [1], [generate PSL data using libidn2])
+  fi
+  if test "$enable_builtin" = "libidn2" ; then
+    AC_DEFINE([BUILTIN_GENERATOR_LIBIDN2], [1], [generate PSL data using libidn2])
+  fi
+fi
+
 if test "$enable_runtime" = "libidn" -o "$enable_builtin" = "libidn"; then
   # Check for libidn
   PKG_CHECK_MODULES([LIBIDN], [libidn], [
@@ -231,6 +267,15 @@ if test "$enable_runtime" = "libidn" -o "$enable_builtin" = "libidn"; then
     AC_SEARCH_LIBS(idna_to_ascii_8z, idn, HAVE_LIBIDN=yes, AC_MSG_ERROR(You requested libidn but it is not installed.))
     LIBS=$OLDLIBS
   ])
+fi
+
+if test "x$HAVE_LIBIDN2" = "xyes" ; then
+  if test "$enable_runtime" = "libidn" ; then
+    AC_DEFINE([WITH_LIBIDN], [1], [generate PSL data using libidn])
+  fi
+  if test "$enable_builtin" = "libidn" ; then
+    AC_DEFINE([BUILTIN_GENERATOR_LIBIDN], [1], [generate PSL data using libidn])
+  fi
 fi
 
 if test "x$HAVE_LIBIDN2" = "xyes" -o "x$HAVE_LIBIDN" = "xyes"; then
@@ -263,6 +308,11 @@ elif test -n "$NEEDS_SOCKET" ; then
   LIBS="$LIBS -lsocket"
 elif test -n "$NEEDS_NSL" ; then
   LIBS="$LIBS -lnsl"
+fi
+
+# Windows has the networking functions in -lws2_32
+if test "x$os_win32" = "xyes" ; then
+  LIBS="$LIBS -lws2_32"
 fi
 
 # Check for clock_gettime() used for performance measurement

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -50,7 +50,15 @@ endif
 endif
 endif
 
-check_PROGRAMS = $(PSL_TESTS)
+# We don't have fmemopen() on Windows, so we can't run these tests
+# on Windows, at least for now
+
+check_PROGRAMS =
+TESTS =
+
+if !OS_WIN32
+  check_PROGRAMS += $(PSL_TESTS)
+endif
 
 dist-hook:
 	find . -name '*.options' -exec cp -v '{}' $(distdir) ';'
@@ -59,7 +67,10 @@ dist-hook:
 	find . -name '*.repro' -exec cp -vr '{}' $(distdir) ';'
 
 TESTS_ENVIRONMENT = TESTS_VALGRIND="@VALGRIND_ENVIRONMENT@"
-TESTS = $(PSL_TESTS)
+
+if !OS_WIN32
+  TESTS += $(PSL_TESTS)
+endif
 
 clean-local:
 	rm -rf *.gc?? *.log lcov coverage.info *_fuzzer *.o

--- a/include/libpsl.h.in
+++ b/include/libpsl.h.in
@@ -40,6 +40,16 @@
 #define PSL_VERSION_PATCH @LIBPSL_VERSION_PATCH@
 #define PSL_VERSION_NUMBER @LIBPSL_VERSION_NUMBER@
 
+#if defined (BUILDING_PSL) && defined (HAVE_VISIBILITY)
+# define PSL_API __attribute__ ((__visibility__("default")))
+#elif  defined (BUILDING_PSL) && defined (_MSC_VER) && !defined (PSL_STATIC)
+# define PSL_API __declspec(dllexport)
+#elif defined (_MSC_VER) && !defined (PSL_STATIC)
+# define PSL_API __declspec(dllimport)
+#else
+# define PSL_API
+#endif
+
 #ifdef  __cplusplus
 extern "C" {
 #endif
@@ -77,90 +87,112 @@ typedef enum {
 typedef struct _psl_ctx_st psl_ctx_t;
 
 /* frees PSL context */
+PSL_API
 void
 	psl_free(psl_ctx_t *psl);
 
 /* frees memory allocated by libpsl routines */
+PSL_API
 void
 	psl_free_string(char *str);
 
 /* loads PSL data from file */
+PSL_API
 psl_ctx_t *
 	psl_load_file(const char *fname);
 
 /* loads PSL data from FILE pointer */
+PSL_API
 psl_ctx_t *
 	psl_load_fp(FILE *fp);
 
 /* retrieves builtin PSL data */
+PSL_API
 const psl_ctx_t *
 	psl_builtin(void);
 
 /* retrieves most recent PSL data */
+PSL_API
 psl_ctx_t *
 	psl_latest(const char *fname);
 
 /* checks whether domain is a public suffix or not */
+PSL_API
 int
 	psl_is_public_suffix(const psl_ctx_t *psl, const char *domain);
 
 /* checks whether domain is a public suffix regarding the type or not */
+PSL_API
 int
 	psl_is_public_suffix2(const psl_ctx_t *psl, const char *domain, int type);
 
 /* checks whether cookie_domain is acceptable for domain or not */
+PSL_API
 int
 	psl_is_cookie_domain_acceptable(const psl_ctx_t *psl, const char *hostname, const char *cookie_domain);
 
 /* returns the longest not registrable domain within 'domain' or NULL if none found */
+PSL_API
 const char *
 	psl_unregistrable_domain(const psl_ctx_t *psl, const char *domain);
 
 /* returns the shortest possible registrable domain part or NULL if domain is not registrable at all */
+PSL_API
 const char *
 	psl_registrable_domain(const psl_ctx_t *psl, const char *domain);
 
 /* convert a string into lowercase UTF-8 */
+PSL_API
 psl_error_t
 	psl_str_to_utf8lower(const char *str, const char *encoding, const char *locale, char **lower);
 
 /* does not include exceptions */
+PSL_API
 int
 	psl_suffix_count(const psl_ctx_t *psl);
 
 /* just counts exceptions */
+PSL_API
 int
 	psl_suffix_exception_count(const psl_ctx_t *psl);
 
 /* just counts wildcards */
+PSL_API
 int
 	psl_suffix_wildcard_count(const psl_ctx_t *psl);
 
 /* returns mtime of PSL source file */
+PSL_API
 time_t
 	psl_builtin_file_time(void);
 
 /* returns SHA1 checksum (hex-encoded, lowercase) of PSL source file */
+PSL_API
 const char *
 	psl_builtin_sha1sum(void);
 
 /* returns file name of PSL source file */
+PSL_API
 const char *
 	psl_builtin_filename(void);
 
 /* returns name of distribution PSL data file */
+PSL_API
 const char *
 	psl_dist_filename(void);
 
 /* returns library version string */
+PSL_API
 const char *
 	psl_get_version(void);
 
 /* checks library version number */
+PSL_API
 int
 	psl_check_version_number(int version);
 
 /* returns whether the built-in data is outdated or not */
+PSL_API
 int
 	psl_builtin_outdated(void);
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,11 @@ CLEANFILES = suffixes_dafsa.c
 lib_LTLIBRARIES = libpsl.la
 
 libpsl_la_SOURCES = psl.c lookup_string_in_fixed_set.c
-libpsl_la_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include -DPSL_DISTFILE=\"$(PSL_DISTFILE)\"
+libpsl_la_CPPFLAGS =	\
+	-I$(top_srcdir)/include	\
+	-I$(top_builddir)/include	\
+	-DPSL_DISTFILE=\"$(PSL_DISTFILE)\"	\
+	-DBUILDING_PSL
 # include ABI version information
 libpsl_la_LDFLAGS = -version-info $(LIBPSL_SO_VERSION)
 if WITH_LIBICU

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,6 +24,10 @@ if WITH_LIBIDN
   libpsl_la_LDFLAGS += -lidn -lunistring
 endif
 
+if OS_WIN32
+  libpsl_la_LDFLAGS += -no-undefined
+endif
+
 # Build rule for suffix_dafsa.c
 # PSL_FILE can be set by ./configure --with-psl-file=[PATH]
 suffixes_dafsa.c: $(PSL_FILE) $(srcdir)/psl-make-dafsa


### PR DESCRIPTION
Hi,

As GNOME's libsoup, which is supported on Windows natively, now depends on the libpsl library, I am proposing some simple changes to the code so that libpsl can build and run on Windows without the need for Cygwin, and so that libsoup will continue to work natively on Windows.

I will also (possibly in another PR) contribute a set of NMake Makefiles to build libpsl under Visual Studio.

With blessings, thank you!