### PR TITLE
Use __has_declspec_attribute for shared builds

### DIFF
--- a/include/libpsl.h.in
+++ b/include/libpsl.h.in
@@ -40,12 +40,16 @@
 #define PSL_VERSION_PATCH @LIBPSL_VERSION_PATCH@
 #define PSL_VERSION_NUMBER @LIBPSL_VERSION_NUMBER@
 
+#ifndef __has_declspec_attribute
+#  define __has_declspec_attribute(x) 0
+#endif
+
 #ifndef PSL_API
 #if defined BUILDING_PSL && HAVE_VISIBILITY
 #  define PSL_API __attribute__ ((__visibility__("default")))
-#elif defined BUILDING_PSL && defined _MSC_VER && !defined PSL_STATIC
+#elif defined BUILDING_PSL && (defined _MSC_VER || (__has_declspec_attribute(dllexport) && __has_declspec_attribute(dllimport))) && !defined PSL_STATIC
 #  define PSL_API __declspec(dllexport)
-#elif defined _MSC_VER && !defined PSL_STATIC
+#elif (defined _MSC_VER || (__has_declspec_attribute(dllexport) && __has_declspec_attribute(dllimport))) && !defined PSL_STATIC
 #  define PSL_API __declspec(dllimport)
 #else
 #  define PSL_API


### PR DESCRIPTION
Clang compilation targets may support `__declspec` attributes. Because of that it has a `__has_declspec_attribute` [check](https://clang.llvm.org/docs/LanguageExtensions.html#has-declspec-attribute).

Currently libpsl just assumes that `__declspec` is Windows only. This adds a compatibility macro and checks whether `dllimport` and `dllexport` are available.