### PR TITLE
Disable build without runtime for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   - RUNTIME=libicu
   - RUNTIME=libidn2
   - RUNTIME=libidn
-  - RUNTIME=no
+#  - RUNTIME=no
 
 addons:
   apt:


### PR DESCRIPTION
When/If publicsuffix/list changes to NFC format, this commit
can be reverted.