### PR TITLE
Update the Meson build files so that things build on Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ libidn2_dep = notfound
 libicu_dep = notfound
 libidn_dep = notfound
 libunistring = notfound
+networking_deps = notfound
 
 # FIXME: Cleanup this when Meson gets 'feature-combo':
 # https://github.com/mesonbuild/meson/issues/4566
@@ -73,6 +74,10 @@ if libidn2_dep.found() or libidn_dep.found()
   libunistring = cc.find_library('unistring')
 endif
 
+if host_machine.system() == 'windows'
+  networking_deps = cc.find_library('ws2_32')
+endif
+
 if enable_runtime == 'auto'
   enable_runtime = 'no'
 endif
@@ -113,6 +118,17 @@ endif
 
 python = import('python').find_installation()
 pkgconfig = import('pkgconfig')
+
+if cc.get_id() == 'msvc'
+  if not cc.has_header_symbol('stdio.h', 'snprintf')
+    if cc.has_header_symbol('stdio.h', '_snprintf')
+      add_project_arguments('-Dsnprintf=_snprintf', language: 'c')
+    endif
+  endif
+  if cc.has_header_symbol('malloc.h', '_alloca')
+    add_project_arguments('-Dalloca=_alloca', language: 'c')
+  endif
+endif
 
 subdir('include')
 subdir('src')

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,7 +3,7 @@ psl_make_dafsa = find_program('psl-make-dafsa')
 suffixes_dafsa_h = custom_target('suffixes_dafsa.h',
   input : psl_file,
   output : 'suffixes_dafsa.h',
-  command : [python, psl_make_dafsa, '--output-format=cxx+', '@INPUT@', '@OUTPUT@'])
+  command : [psl_make_dafsa, '--output-format=cxx+', '@INPUT@', '@OUTPUT@'])
 
 sources = [
   'lookup_string_in_fixed_set.c',
@@ -19,7 +19,7 @@ cargs = [
 libpsl = library('psl', sources, suffixes_dafsa_h,
   include_directories : [configinc, includedir],
   c_args : cargs,
-  dependencies : [libidn2_dep, libidn_dep, libicu_dep, libunistring],
+  dependencies : [libidn2_dep, libidn_dep, libicu_dep, libunistring, networking_deps],
 )
 
 pkgconfig.generate(libpsl,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,12 +1,12 @@
 psl_dafsa = custom_target('psl.dafsa',
   input : psl_file,
   output : 'psl.dafsa',
-  command : [python, psl_make_dafsa, '--output-format=binary', '@INPUT@', '@OUTPUT@'])
+  command : [psl_make_dafsa, '--output-format=binary', '@INPUT@', '@OUTPUT@'])
 
 psl_ascii_dafsa = custom_target('psl_ascii.dafsa',
   input : psl_file,
   output : 'psl_ascii.dafsa',
-  command : [python, psl_make_dafsa, '--output-format=binary', '--encoding=ascii', '@INPUT@', '@OUTPUT@'])
+  command : [psl_make_dafsa, '--output-format=binary', '--encoding=ascii', '@INPUT@', '@OUTPUT@'])
 
 tests_cargs = [
   '-DHAVE_CONFIG_H',


### PR DESCRIPTION
Hi,

As part of the steps to simplify the build system, this completes the support that is needed for libpsl to build on Windows using Meson, especially for Visual Studio builds.  After this gets merged, I think this will replace the NMake Makefiles that is used to build libpsl on Visual Studio.

With blessings, thank you!