### PR TITLE
Fix older windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -310,8 +310,18 @@ elif test -n "$NEEDS_SOCKET" ; then
 elif test -n "$NEEDS_NSL" ; then
   LIBS="$LIBS -lnsl"
 else
-  # Needed for MinGW / Windows
-  AC_SEARCH_LIBS(inet_pton, ws2_32)
+  # Platform dependant options
+  case "${host_os}" in
+    # MinGW / Windows
+    *mingw*)
+      # Select Windows NT/2000 and later, for WSAStringToAddressW()
+      CPPFLAGS="$CPPFLAGS -D_WIN32_WINNT=0x500"
+      # Needed for network support
+      LIBS="$LIBS -lws2_32"
+      ;;
+    *)
+      ;;
+  esac
 fi
 
 # Check for clock_gettime() used for performance measurement


### PR DESCRIPTION
At the moment the library requires Windows Vista or later, when working on Microsoft Windows.
I would like to suggest to not use inet_pton() on Windows and use the Winsock function that exists for the same purpose. The attached PR allows the library to run starting from Windows NT 2000. Actually the functions added for better compatibility with BSD are also based on Winsock, so I think that there are not pratical problems with this change.

Sincerely.