### PR TITLE
Fix build when configured with --with-psl-file

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -33,9 +33,9 @@ TESTS = $(PSL_TESTS)
 # dafsa.psl and dafsa_ascii.psl must be created before any test is executed
 # check-local target works in parallel to the tests, so the test suite will likely fail
 BUILT_SOURCES = psl.dafsa psl_ascii.dafsa
-psl.dafsa: $(top_srcdir)/list/public_suffix_list.dat
+psl.dafsa: $(PSL_FILE)
 	$(top_srcdir)/src/psl-make-dafsa --output-format=binary "$(PSL_FILE)" psl.dafsa
-psl_ascii.dafsa: $(top_srcdir)/list/public_suffix_list.dat
+psl_ascii.dafsa: $(PSL_FILE)
 	$(top_srcdir)/src/psl-make-dafsa --output-format=binary --encoding=ascii "$(PSL_FILE)" psl_ascii.dafsa
 
 clean-local:


### PR DESCRIPTION
The error message is as follows:
```
Making all in tests
make: don't know how to make ../list/public_suffix_list.dat. Stop

make: stopped in /usr/ports/works/usr/ports/dns/libpsl/work/libpsl-libpsl-0.21.0/tests
*** Error code 1

Stop.
```

PSL_FILE defaults to $(top_srcdir)/list/public_suffix_list.dat. When configured with --with-psl-file, the non-default PSL_FILE breaks the build in tests directory. Use $(PSL_FILE) instead of hardcoded $(top_srcdir)/list/public_suffix_list.dat to fix the build.