### PR TITLE
gtk-doc: do not include tree_index.sgml

### DIFF
--- a/docs/libpsl/libpsl-docs.sgml
+++ b/docs/libpsl/libpsl-docs.sgml
@@ -22,10 +22,6 @@
         </para>
         <xi:include href="xml/libpsl.xml"/>
   </chapter>
-  <chapter id="object-tree">
-    <title>Object Hierarchy</title>
-     <xi:include href="xml/tree_index.sgml"/>
-  </chapter>
   <index id="api-index-full">
     <title>API Index</title>
     <xi:include href="xml/api-index-full.xml"><xi:fallback /></xi:include>


### PR DESCRIPTION
gtk-doc 1.30 no longer generates the file if the object tree is empty.