### PR TITLE
Makefile.am: use PYTHON when invoking psl-make-dafsa

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,7 +19,7 @@ libpsl_la_LDFLAGS = -no-undefined -version-info $(LIBPSL_SO_VERSION)
 # Build rule for suffix_dafsa.c
 # PSL_FILE can be set by ./configure --with-psl-file=[PATH]
 suffixes_dafsa.h: $(PSL_FILE) $(srcdir)/psl-make-dafsa
-	$(srcdir)/psl-make-dafsa --output-format=cxx+ "$(PSL_FILE)" suffixes_dafsa.h
+	$(PYTHON) $(srcdir)/psl-make-dafsa --output-format=cxx+ "$(PSL_FILE)" suffixes_dafsa.h
 
 EXTRA_DIST = psl-make-dafsa LICENSE.chromium meson.build
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,9 +34,9 @@ TESTS = $(PSL_TESTS)
 # check-local target works in parallel to the tests, so the test suite will likely fail
 BUILT_SOURCES = psl.dafsa psl_ascii.dafsa
 psl.dafsa: $(PSL_FILE)
-	$(top_srcdir)/src/psl-make-dafsa --output-format=binary "$(PSL_FILE)" psl.dafsa
+	$(PYTHON) $(top_srcdir)/src/psl-make-dafsa --output-format=binary "$(PSL_FILE)" psl.dafsa
 psl_ascii.dafsa: $(PSL_FILE)
-	$(top_srcdir)/src/psl-make-dafsa --output-format=binary --encoding=ascii "$(PSL_FILE)" psl_ascii.dafsa
+	$(PYTHON) $(top_srcdir)/src/psl-make-dafsa --output-format=binary --encoding=ascii "$(PSL_FILE)" psl_ascii.dafsa
 
 clean-local:
 	rm -f psl.dafsa psl_ascii.dafsa


### PR DESCRIPTION
In an environment where only Python 3 is installed, configure.ac finds and sets
PYTHON=python3 correctly but src/psl-make-dafsa is called directly, so the hashbang of
`#!/usr/bin/env python` is used which doesn't exist.

Fix this by explicitly running $(PYTHON) when using the tool.