### PR TITLE
Improve Visual Studio builds Add instructions

### DIFF
--- a/README.MSVC.md
+++ b/README.MSVC.md
@@ -36,8 +36,9 @@ and libpsl header, into appropriate locations under PREFIX (please see
 below).
 
 This will build the libpsl DLL/LIB and the psl.exe utility in the
-$(CFG)\$(ARCH) subdirectory, where ARCH is Win32 for 32-bit builds
-and x64 for 64-bit (x86_64) builds.
+vsX\$(CFG)\$(ARCH) subdirectory, where X is the release version
+of Visual Studio, such as 9 for 2008 and 16 for 2019, and ARCH is 
+Win32 for 32-bit builds and x64 for 64-bit (x86_64) builds.
 
 A number of options can be passed into the NMake command, as follows.
 Enable by setting each option to 1, unless otherwise indicated:

--- a/README.MSVC.md
+++ b/README.MSVC.md
@@ -1,0 +1,137 @@
+Building libpsl with Visual Studio
+==================================
+
+Building libpsl for Windows using Visual Studio 2008 or later is
+supported with NMake (from release tarballs) or Meson (from GIT
+checkouts).  The following sections will cover building libpsl with
+these methods.
+
+Currently, for builtin/runtime public suffix list (PSL) IDNA handling,
+only ICU is supported for Visual Studio builds.
+
+Using NMake (from a release tarball)
+===========
+You will need a Python 2.7.x or later installation in order to
+complete the build successfully.
+
+You will need the ICU (International Components for Unicode)
+libraries, headers and DLLs, to build libpsl, unless both
+DISABLE_BUILTIN=1 and DISABLE_RUNTIME=1 are passed into the NMake
+command line as listed below.
+
+You can also buid libpsl with libiconv and gettext support, please
+see the options below for enabling such support.
+
+In a Visual Studio command prompt which matches your desired
+configuration (x86/Win32, x64 etc.),
+go to $(srcroot)\msvc, and issue the following command:
+
+nmake /f Makefile.vc CFG=[debug|release]
+
+A 'test' target is provided to build the test programs, while a
+'clean' target is provided to remove all the compiled and generated
+files for the build.  An 'install' target is provided to copy the
+build PSL DLL, .lib and executables, as well as the related PDB files
+and libpsl header, into appropriate locations under PREFIX (please see
+below).
+
+This will build the libpsl DLL/LIB and the psl.exe utility in the
+$(CFG)\$(ARCH) subdirectory, where ARCH is Win32 for 32-bit builds
+and x64 for 64-bit (x86_64) builds.
+
+A number of options can be passed into the NMake command, as follows.
+Enable by setting each option to 1, unless otherwise indicated:
+
+*  PSL_FILE: Location of the PSL data file, which is retrieved from
+             https://publicsuffix.org/list/public_suffix_list.dat,
+             or some other custom location (not supported).  Default
+             is in $(srcroot)\list\public_suffix_list.dat.  This is
+             needed to generate the suffixes_dafsa.h header required
+             for the build, as well as the binary and ascii dafsa
+             files used for the test programs.
+
+*  TEST_PSL_FILE: Location of the test PSL file.  Default is in
+                  $(srcroot)\list\tests\tests.txt.  This is
+                  required for building and running the test
+                  programs.
+
+*  STATIC: Set if building static versions of libpsl is desired.
+
+*  USE_LIBTOOL_DLLNAME: Set to use libtool-style DLL naming.
+
+*  DISABLE_RUNTIME: Do not use ICU to generate runtime PSL data.
+
+*  DISABLE_BUILTIN: Do not use ICU to generate builtin PSL data.
+
+*  USE_ICONV: Enable libiconv support, requires libiconv.
+
+*  USE_GETTEXT: Enable gettext support for displaying i18n messages.
+                Implies USE_ICONV, and requires gettext-runtime.
+
+*  PYTHON: Full path to a Python 2.7.x (or later) interpreter, if not
+           already in your PATH.
+           Required to generate DAFSA headers and data files that is
+           needed for the build, as well as generating pkg-config
+           files for NMake builds.
+
+*  PREFIX: Base installation path of the build.  Note that any dependent
+           libraries are searched first from the include\ and lib\
+           sub-directories in PREFIX before searching in the paths
+           specified by %INCLUDE% and %LIB%.  Default is
+           $(srcroot)\..\vsX\$(PLATFORM), where X is the release version
+           of Visual Studio, such as 9 for 2008 and 16 for 2019,
+           $(PLATFORM) is the target platform (Win32/x64) of the build.
+
+Building libpsl with Meson
+==========================
+Building using Meson is now supported for Visual Studio builds from a
+GIT checkout.
+
+Besides the requirements listed in the NMake builds, you will also need
+
+*  Python 3.5.x or later
+*  Meson build system, use PIP to install from Python 3.5.x64
+*  Ninja build tool (if not involking Meson with --backend=
+   vs[2010|2015|2017|2019])
+*  A compatible PSL data file and a test PSL data file.  You may
+   consider using the ones shipped with the latest libpsl release
+   tarball and place the PSL data file in $(srcroot)/list and the
+   test PSL data file in $(srcroot)/list/tests.  You may also choose
+   to download the latest PSL data file from
+   https://publicsuffix.org/list/public_suffix_list.dat and place it
+   it $(srcroot)/list.  Alternatively, specify
+   -Dpsl_file=<path_to_psl_data_file> and/or
+   -Dpsl_testfile=<path_to_test_psl_data_file> when invoking Meson.
+
+Open a Visual Studio command prompt and enter an empty build directory.
+
+Your Python interpreter, Meson executable script and Ninja (if used)
+need to be in your PATH.
+
+Any dependent libraries that are being used should have their headers
+found in paths specified by %INCLUDE% and their .lib files in the
+paths specified by %LIB%.
+
+In the empty build directory, run the following:
+
+meson <path_to_libpsl_git_checkout> --buildtype=... --prefix=<some_prefix> [--backend=vs[2010|2015|2017|2019]]
+
+Please see the Meson documentation for the values accepted by
+--buildtype.  --backend=vsXXXX generates the corresponding versions
+of the Visual Studio solution files to build libpsl, which
+will elimnate the need to have the Ninja build tool installed.
+
+When the Meson configuration completes, run 'ninja' or open the
+generated solution files with Visual Studio and build the projects
+to carry out the build.  Run 'ninja test' or the test project to
+test the build and run 'ninja install' or 'ninja install' to
+install the build results.
+
+If building with Visual Studio 2008, run the following after running
+'ninja install' in your builddir:
+
+for /r %f in (*.dll.manifest) do if exist $(prefix)\bin\%~nf mt /manifest %f /outputresource:$(prefix)\bin\%~nf;2
+
+for /r %f in (*.exe.manifest) do if exist $(prefix)\bin\%~nf mt /manifest %f /outputresource:$(prefix)\bin\%~nf;1
+
+So that the application manifests get properly embedded.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ If you prefer a `meson` build
 		ninja -C builddir
 		ninja -C builddir test
 
-There is also an unofficial MSVC nmake build configuration in `msvc/`.
+There is also an unofficial MSVC nmake build configuration in `msvc/`.   Please
+see README.MSVC.md on building libpsl with Visual Studio via NMake or Meson.
 
 
 Mailing List

--- a/msvc/build-rules-msvc.mak
+++ b/msvc/build-rules-msvc.mak
@@ -15,12 +15,12 @@
 # <<
 
 {..\src\}.c{vs$(VSVER)\$(CFG)\$(PLAT)\libpsl\}.obj::
-	$(CC) $(BASE_CFLAGS) $(PSL_ADDITIONAL_CFLAGS) $(PSL_INCLUDES) /Fovs$(VSVER)\$(CFG)\$(PLAT)\libpsl\ /c @<<
+	$(CC) $(BASE_CFLAGS) $(PSL_ADDITIONAL_CFLAGS) $(PSL_INCLUDES) /Fovs$(VSVER)\$(CFG)\$(PLAT)\libpsl\ /Fdvs$(VSVER)\$(CFG)\$(PLAT)\libpsl\ /c @<<
 $<
 <<
 
 {..\tools\}.c{vs$(VSVER)\$(CFG)\$(PLAT)\psl\}.obj::
-	$(CC) $(BASE_CFLAGS) $(PSL_INCLUDES) /Fovs$(VSVER)\$(CFG)\$(PLAT)\psl\ /c @<<
+	$(CC) $(BASE_CFLAGS) $(PSL_INCLUDES) /Fovs$(VSVER)\$(CFG)\$(PLAT)\psl\ /Fdvs$(VSVER)\$(CFG)\$(PLAT)\psl\ /c @<<
 $<
 <<
 
@@ -38,7 +38,9 @@ vs$(VSVER)\$(CFG)\$(PLAT)\libpsl\psl.obj: vs$(VSVER)\$(CFG)\$(PLAT)\libpsl\suffi
 {..\tests\}.c{vs$(VSVER)\$(CFG)\$(PLAT)\}.exe:
 	@if not exist $(PSL_UTILS) $(MAKE) -f Makefile.vc $(PSL_MAKE_OPTIONS) $(PSL_UTILS)
 	@if not exist vs$(VSVER)\$(CFG)\$(PLAT)\tests $(MAKE) -f Makefile.vc $(PSL_MAKE_OPTIONS) vs$(VSVER)\$(CFG)\$(PLAT)\tests
-	$(CC) $(PSL_TEST_CFLAGS) $(PSL_INCLUDES) /Fovs$(VSVER)\$(CFG)\$(PLAT)\tests\ /Fe$@	\
+	$(CC) $(PSL_TEST_CFLAGS) $(PSL_INCLUDES)	\
+	/Fovs$(VSVER)\$(CFG)\$(PLAT)\tests\	\
+	/Fdvs$(VSVER)\$(CFG)\$(PLAT)\tests\ /Fe$@	\
 	$< /link $(LDFLAGS) $(PSL_LIB) $(PSL_ADDITIONAL_LIBS)
 	@if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;1
 
@@ -102,9 +104,12 @@ clean:
 	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.dll.manifest
 	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.dll
 	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.ilk
+	@-if exist vs$(VSVER)\$(CFG)\$(PLAT)\tests del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\tests\*.pdb
 	@-if exist vs$(VSVER)\$(CFG)\$(PLAT)\tests del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\tests\*.obj
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\psl\*.pdb
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\psl\*.obj
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libpsl\*.pdb
 	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libpsl\*.obj
 	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libpsl\suffixes_dafsa.h
 	@-del /f /q ..\config.h
-	@-del /f /q vc$(PDBVER)0.pdb
 	@-rmdir /s /q vs$(VSVER)\$(CFG)\$(PLAT)

--- a/msvc/build-rules-msvc.mak
+++ b/msvc/build-rules-msvc.mak
@@ -14,18 +14,18 @@
 # $<
 # <<
 
-{..\src\}.c{$(CFG)\$(PLAT)\libpsl\}.obj::
-	$(CC) $(BASE_CFLAGS) $(PSL_ADDITIONAL_CFLAGS) $(PSL_INCLUDES) /Fo$(CFG)\$(PLAT)\libpsl\ /c @<<
+{..\src\}.c{vs$(VSVER)\$(CFG)\$(PLAT)\libpsl\}.obj::
+	$(CC) $(BASE_CFLAGS) $(PSL_ADDITIONAL_CFLAGS) $(PSL_INCLUDES) /Fovs$(VSVER)\$(CFG)\$(PLAT)\libpsl\ /c @<<
 $<
 <<
 
-{..\tools\}.c{$(CFG)\$(PLAT)\psl\}.obj::
-	$(CC) $(BASE_CFLAGS) $(PSL_INCLUDES) /Fo$(CFG)\$(PLAT)\psl\ /c @<<
+{..\tools\}.c{vs$(VSVER)\$(CFG)\$(PLAT)\psl\}.obj::
+	$(CC) $(BASE_CFLAGS) $(PSL_INCLUDES) /Fovs$(VSVER)\$(CFG)\$(PLAT)\psl\ /c @<<
 $<
 <<
 
 # Make sure we generate suffixes_dafsa.h before trying to compile psl.c
-$(CFG)\$(PLAT)\libpsl\psl.obj: $(CFG)\$(PLAT)\libpsl\suffixes_dafsa.h
+vs$(VSVER)\$(CFG)\$(PLAT)\libpsl\psl.obj: vs$(VSVER)\$(CFG)\$(PLAT)\libpsl\suffixes_dafsa.h
 
 # Inference rules for building the test programs
 # Used for programs with a single source file.
@@ -35,16 +35,16 @@ $(CFG)\$(PLAT)\libpsl\psl.obj: $(CFG)\$(PLAT)\libpsl\suffixes_dafsa.h
 # {$(srcdir)}.$(srcext){$(destdir)}.exe::
 # 	$(CC)|$(CXX) $(cflags) $< /Fo$*.obj  /Fe$@ [/link $(linker_flags) $(dep_libs)]
 
-{..\tests\}.c{$(CFG)\$(PLAT)\}.exe:
+{..\tests\}.c{vs$(VSVER)\$(CFG)\$(PLAT)\}.exe:
 	@if not exist $(PSL_UTILS) $(MAKE) -f Makefile.vc $(PSL_MAKE_OPTIONS) $(PSL_UTILS)
-	@if not exist $(CFG)\$(PLAT)\tests $(MAKE) -f Makefile.vc $(PSL_MAKE_OPTIONS) $(CFG)\$(PLAT)\tests
-	$(CC) $(PSL_TEST_CFLAGS) $(PSL_INCLUDES) /Fo$(CFG)\$(PLAT)\tests\ /Fe$@	\
+	@if not exist vs$(VSVER)\$(CFG)\$(PLAT)\tests $(MAKE) -f Makefile.vc $(PSL_MAKE_OPTIONS) vs$(VSVER)\$(CFG)\$(PLAT)\tests
+	$(CC) $(PSL_TEST_CFLAGS) $(PSL_INCLUDES) /Fovs$(VSVER)\$(CFG)\$(PLAT)\tests\ /Fe$@	\
 	$< /link $(LDFLAGS) $(PSL_LIB) $(PSL_ADDITIONAL_LIBS)
 	@if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;1
 
 # Rules for building .lib files
 !ifdef STATIC
-$(PSL_LIB): $(CFG)\$(PLAT)\libpsl ..\config.h $(libpsl_OBJS)
+$(PSL_LIB): vs$(VSVER)\$(CFG)\$(PLAT)\libpsl ..\config.h $(libpsl_OBJS)
 	lib $(ARFLAGS) /out:$@ @<<
 $(libpsl_OBJS)
 <<
@@ -75,7 +75,7 @@ $(libpsl_OBJS)
 # <<
 # 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;1
 
-$(CFG)\$(PLAT)\psl.exe: $(PSL_LIB) $(CFG)\$(PLAT)\psl $(psl_OBJS)
+vs$(VSVER)\$(CFG)\$(PLAT)\psl.exe: $(PSL_LIB) vs$(VSVER)\$(CFG)\$(PLAT)\psl $(psl_OBJS)
 	link $(LDFLAGS) $(PSL_LIB) $(PSL_ADDITIONAL_LIBS) /PDB:$(@R)-tool.pdb /out:$@ @<<
 $(psl_OBJS)
 <<
@@ -93,18 +93,18 @@ build-info:
 	@if not "$(ENABLED_BUILTIN)" == "none" echo PSL File: $(PSL_FILE)
 
 clean:
-	@if exist $(CFG)\$(PLAT)\psl.dafsa del $(CFG)\$(PLAT)\psl.dafsa
-	@if exist $(CFG)\$(PLAT)\psl_ascii.dafsa del $(CFG)\$(PLAT)\psl_ascii.dafsa
+	@if exist vs$(VSVER)\$(CFG)\$(PLAT)\psl.dafsa del vs$(VSVER)\$(CFG)\$(PLAT)\psl.dafsa
+	@if exist vs$(VSVER)\$(CFG)\$(PLAT)\psl_ascii.dafsa del vs$(VSVER)\$(CFG)\$(PLAT)\psl_ascii.dafsa
 	@if exist .\libpsl.pc del /f /q .\libpsl.pc
-	@-del /f /q $(CFG)\$(PLAT)\*.exe
-	@-del /f /q $(CFG)\$(PLAT)\*.lib
-	@-del /f /q $(CFG)\$(PLAT)\*.pdb
-	@-del /f /q $(CFG)\$(PLAT)\*.dll.manifest
-	@-del /f /q $(CFG)\$(PLAT)\*.dll
-	@-del /f /q $(CFG)\$(PLAT)\*.ilk
-	@-if exist $(CFG)\$(PLAT)\tests del /f /q $(CFG)\$(PLAT)\tests\*.obj
-	@-del /f /q $(CFG)\$(PLAT)\libpsl\*.obj
-	@-del /f /q $(CFG)\$(PLAT)\libpsl\suffixes_dafsa.h
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.exe
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.lib
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.pdb
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.dll.manifest
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.dll
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.ilk
+	@-if exist vs$(VSVER)\$(CFG)\$(PLAT)\tests del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\tests\*.obj
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libpsl\*.obj
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libpsl\suffixes_dafsa.h
 	@-del /f /q ..\config.h
 	@-del /f /q vc$(PDBVER)0.pdb
-	@-rmdir /s /q $(CFG)\$(PLAT)
+	@-rmdir /s /q vs$(VSVER)\$(CFG)\$(PLAT)

--- a/msvc/config-msvc.mak.in
+++ b/msvc/config-msvc.mak.in
@@ -128,7 +128,12 @@ BASE_CFLAGS = $(BASE_CFLAGS) /DUSE_ICONV=1
 PSL_MAKE_OPTIONS = $(PSL_MAKE_OPTIONS) USE_ICONV^=1
 !endif
 
-PSL_TEST_CFLAGS = $(BASE_CFLAGS) /DPSL_TESTFILE=\"$(PSL_TESTFILE_INPUT)\" /DPSL_FILE=\"$(PSL_FILE_INPUT)\"
+PSL_TEST_CFLAGS =	\
+	$(BASE_CFLAGS)	\
+	/DPSL_TESTFILE=\"$(PSL_TESTFILE_INPUT)\"	\
+	/DPSL_FILE=\"$(PSL_FILE_INPUT)\"	\
+	/DPSL_DAFSA=\"$(MAKEDIR:\=/)/$(CFG)/$(PLAT)/psl.dafsa\" 	\
+	/DPSL_ASCII_DAFSA=\"$(MAKEDIR:\=/)/$(CFG)/$(PLAT)/psl_ascii.dafsa\"
 
 # Visual Studio 2013 or earlier does not have snprintf(),
 # so use _snprintf() which seems to be enough for our purposes

--- a/msvc/config-msvc.mak.in
+++ b/msvc/config-msvc.mak.in
@@ -49,20 +49,20 @@ BASE_CFLAGS =	\
 	/DHAVE_CONFIG_H				\
 	/Dssize_t="$(SSIZE_T_DEF)"
 
-PSL_INCLUDES = /I..\include /I.. /I$(CFG)\$(PLAT)\libpsl /I$(PREFIX)\include
+PSL_INCLUDES = /I..\include /I.. /Ivs$(VSVER)\$(CFG)\$(PLAT)\libpsl /I$(PREFIX)\include
 
 # We build the psl.dll or psl.lib at least, with the psl.exe utility
-PSL_LIB = $(CFG)\$(PLAT)\psl.lib
-PSL_UTILS = $(CFG)\$(PLAT)\psl.exe
+PSL_LIB = vs$(VSVER)\$(CFG)\$(PLAT)\psl.lib
+PSL_UTILS = vs$(VSVER)\$(CFG)\$(PLAT)\psl.exe
 
 PSL_TESTS =	\
-	$(CFG)\$(PLAT)\test-is-public.exe		\
-	$(CFG)\$(PLAT)\test-is-public-all.exe	\
-	$(CFG)\$(PLAT)\test-is-cookie-domain-acceptable.exe
+	vs$(VSVER)\$(CFG)\$(PLAT)\test-is-public.exe		\
+	vs$(VSVER)\$(CFG)\$(PLAT)\test-is-public-all.exe	\
+	vs$(VSVER)\$(CFG)\$(PLAT)\test-is-cookie-domain-acceptable.exe
 
 PSL_TEST_DATA =	\
-	$(CFG)\$(PLAT)\psl.dafsa	\
-	$(CFG)\$(PLAT)\psl_ascii.dafsa
+	vs$(VSVER)\$(CFG)\$(PLAT)\psl.dafsa	\
+	vs$(VSVER)\$(CFG)\$(PLAT)\psl_ascii.dafsa
 
 PSL_MAKE_OPTIONS = CFG^=$(CFG)
 
@@ -77,7 +77,7 @@ PSL_DLL_SUFFIX =
 !endif
 !endif
 
-PSL_DLL = $(CFG)\$(PLAT)\$(PSL_DLL_PREFIX)psl$(PSL_DLL_SUFFIX).dll
+PSL_DLL = vs$(VSVER)\$(CFG)\$(PLAT)\$(PSL_DLL_PREFIX)psl$(PSL_DLL_SUFFIX).dll
 
 # ENABLE_RUNTIME_ICU and ENABLE_BUILTIN_ICU are currently dummy arguments to NMake
 ENABLED_RUNTIME =
@@ -111,8 +111,8 @@ PSL_LIBTYPE = DLL
 PSL_ADDITIONAL_LIBS = $(PSL_ADDITIONAL_LIBS) $(ICUUC_LIB)
 PSL_TESTS =	\
 	$(PSL_TESTS)	\
-	$(CFG)\$(PLAT)\test-is-public-builtin.exe	\
-	$(CFG)\$(PLAT)\test-registrable-domain.exe
+	vs$(VSVER)\$(CFG)\$(PLAT)\test-is-public-builtin.exe	\
+	vs$(VSVER)\$(CFG)\$(PLAT)\test-registrable-domain.exe
 !endif
 
 !ifdef USE_GETTEXT
@@ -132,8 +132,8 @@ PSL_TEST_CFLAGS =	\
 	$(BASE_CFLAGS)	\
 	/DPSL_TESTFILE=\"$(PSL_TESTFILE_INPUT)\"	\
 	/DPSL_FILE=\"$(PSL_FILE_INPUT)\"	\
-	/DPSL_DAFSA=\"$(MAKEDIR:\=/)/$(CFG)/$(PLAT)/psl.dafsa\" 	\
-	/DPSL_ASCII_DAFSA=\"$(MAKEDIR:\=/)/$(CFG)/$(PLAT)/psl_ascii.dafsa\"
+	/DPSL_DAFSA=\"$(MAKEDIR:\=/)/vs$(VSVER)/$(CFG)/$(PLAT)/psl.dafsa\" 	\
+	/DPSL_ASCII_DAFSA=\"$(MAKEDIR:\=/)/vs$(VSVER)/$(CFG)/$(PLAT)/psl_ascii.dafsa\"
 
 # Visual Studio 2013 or earlier does not have snprintf(),
 # so use _snprintf() which seems to be enough for our purposes

--- a/msvc/create-lists-msvc.mak
+++ b/msvc/create-lists-msvc.mak
@@ -40,7 +40,7 @@ NULL=
 !if [call create-lists.bat header libpsl-msvc.mak libpsl_OBJS]
 !endif
 
-!if [for %c in ($(LIBPSL_SRCS)) do @if "%~xc" == ".c" @call create-lists.bat file libpsl-msvc.mak ^$(CFG)\^$(PLAT)\libpsl\%~nc.obj]
+!if [for %c in ($(LIBPSL_SRCS)) do @if "%~xc" == ".c" @call create-lists.bat file libpsl-msvc.mak vs^$(VSVER)\^$(CFG)\^$(PLAT)\libpsl\%~nc.obj]
 !endif
 
 !if [call create-lists.bat footer libpsl-msvc.mak]
@@ -49,7 +49,7 @@ NULL=
 !if [call create-lists.bat header libpsl-msvc.mak psl_OBJS]
 !endif
 
-!if [for %c in (..\tools\*.c) do @call create-lists.bat file libpsl-msvc.mak ^$(CFG)\^$(PLAT)\psl\%~nc.obj]
+!if [for %c in (..\tools\*.c) do @call create-lists.bat file libpsl-msvc.mak vs^$(VSVER)\^$(CFG)\^$(PLAT)\psl\%~nc.obj]
 !endif
 
 !if [call create-lists.bat footer libpsl-msvc.mak]

--- a/msvc/detectenv-msvc.mak
+++ b/msvc/detectenv-msvc.mak
@@ -89,8 +89,10 @@ VSVER = 11
 VSVER = 12
 !elseif $(VCVERSION) > 1899 && $(VCVERSION) < 1910
 VSVER = 14
-!elseif $(VCVERSION) > 1909 && $(VCVERSION) < 2000
+!elseif $(VCVERSION) > 1909 && $(VCVERSION) < 1920
 VSVER = 15
+!elseif $(VCVERSION) > 1919 && $(VCVERSION) < 2000
+VSVER = 16
 !else
 VSVER = 0
 !endif
@@ -98,7 +100,7 @@ VSVER = 0
 !if "$(VSVER)" == "0"
 MSG = ^
 This NMake Makefile set supports Visual Studio^
-9 (2008) through 14 (2015).  Your Visual Studio^
+9 (2008) through 16 (2019).  Your Visual Studio^
 version is not supported.
 !error $(MSG)
 !elseif $(VSVER) < 15

--- a/msvc/generate-msvc.mak
+++ b/msvc/generate-msvc.mak
@@ -4,20 +4,20 @@
 # one is maintaining the NMake build files.
 
 # Create the build directories
-$(CFG)\$(PLAT)\libpsl	\
-$(CFG)\$(PLAT)\psl	\
-$(CFG)\$(PLAT)\tests:
+vs$(VSVER)\$(CFG)\$(PLAT)\libpsl	\
+vs$(VSVER)\$(CFG)\$(PLAT)\psl	\
+vs$(VSVER)\$(CFG)\$(PLAT)\tests:
 	@-md $@
 
-$(CFG)\$(PLAT)\libpsl\suffixes_dafsa.h: $(CFG)\$(PLAT)\libpsl $(PSL_FILE) ..\src\psl-make-dafsa
+vs$(VSVER)\$(CFG)\$(PLAT)\libpsl\suffixes_dafsa.h: vs$(VSVER)\$(CFG)\$(PLAT)\libpsl $(PSL_FILE) ..\src\psl-make-dafsa
 	@echo Generating $@
 	$(PYTHON) ..\src\psl-make-dafsa --output-format=cxx+ "$(PSL_FILE_INPUT)" $@
 
-$(CFG)\$(PLAT)\psl.dafsa: $(CFG)\$(PLAT)\tests
+vs$(VSVER)\$(CFG)\$(PLAT)\psl.dafsa: vs$(VSVER)\$(CFG)\$(PLAT)\tests
 	@echo Generating $@
 	$(PYTHON) ..\src\psl-make-dafsa --output-format=binary "$(PSL_FILE_INPUT)" $@
 
-$(CFG)\$(PLAT)\psl_ascii.dafsa: $(CFG)\$(PLAT)\tests
+vs$(VSVER)\$(CFG)\$(PLAT)\psl_ascii.dafsa: vs$(VSVER)\$(CFG)\$(PLAT)\tests
 	@echo Generating $@
 	$(PYTHON) ..\src\psl-make-dafsa --output-format=binary --encoding=ascii "$(PSL_FILE_INPUT)" $@
 

--- a/msvc/install-msvc.mak
+++ b/msvc/install-msvc.mak
@@ -5,10 +5,10 @@ install: all libpsl.pc build-info
 	@if not exist $(PREFIX)\bin\ mkdir $(PREFIX)\bin
 	@if not exist $(PREFIX)\lib\pkgconfig\ mkdir $(PREFIX)\lib\pkgconfig
 	@if not exist $(PREFIX)\include @mkdir $(PREFIX)\include
-	@copy /b $(CFG)\$(PLAT)\psl.exe $(PREFIX)\bin
-	@copy /b $(CFG)\$(PLAT)\psl-tool.pdb $(PREFIX)\bin
+	@copy /b vs$(VSVER)\$(CFG)\$(PLAT)\psl.exe $(PREFIX)\bin
+	@copy /b vs$(VSVER)\$(CFG)\$(PLAT)\psl-tool.pdb $(PREFIX)\bin
 	@if "$(PSL_LIBTYPE)" == "DLL" copy /b $(PSL_DLL) $(PREFIX)\bin
-	@if "$(PSL_LIBTYPE)" == "DLL" copy /b $(CFG)\$(PLAT)\psl.pdb $(PREFIX)\bin
-	@copy /b $(CFG)\$(PLAT)\psl.lib $(PREFIX)\lib
+	@if "$(PSL_LIBTYPE)" == "DLL" copy /b vs$(VSVER)\$(CFG)\$(PLAT)\psl.pdb $(PREFIX)\bin
+	@copy /b vs$(VSVER)\$(CFG)\$(PLAT)\psl.lib $(PREFIX)\lib
 	@copy libpsl.pc $(PREFIX)\lib\pkgconfig
 	@for %h in (..\include\*.h) do @copy %h $(PREFIX)\include\%~nxh


### PR DESCRIPTION
Hi,

This attempts to improve Visual Studio NMake builds by:

*  Fix test program builds, as new macro defines are needed to locate the generated dafsa data files.
*  Support Visual Studio 2019 better.
*  Separate intermediate PDBs during the build.
*  Differentiate builds between Visual Studio versions.

Since we also support Meson for Visual Studio builds, we also:
*  Add instructions on building libpsl on Visual Studio with NMake and Visual Studio (issue #145).

With blessings, thank you! 