### PR TITLE
meson: Use libtool library versioning, same as autotools

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,9 @@ project('libpsl', 'c',
   version : '0.20.2',
   meson_version : '>=0.47.0')
 
+# Derived from LIBPSL_SO_VERSION in configure.ac
+lt_version = '5.3.2'
+
 cc = meson.get_compiler('c')
 
 enable_runtime = get_option('runtime')

--- a/src/meson.build
+++ b/src/meson.build
@@ -20,6 +20,7 @@ libpsl = library('psl', sources, suffixes_dafsa_h,
   include_directories : [configinc, includedir],
   c_args : cargs,
   dependencies : [libidn2_dep, libidn_dep, libicu_dep, libunistring, networking_deps],
+  version: lt_version,
   install: true,
 )
 


### PR DESCRIPTION
This helps maintain ABI compatibility with the Autotools build so it's a drop-in replacement.

Previously we only outputted `libpsl.so`. Now we output:

```
libpsl.so -> libpsl.so.5
libpsl.so.5 -> libpsl.so.5.3.2
libpsl.so.5.3.2
```

Which is ABI-compatible with what autotools outputs:

```
libpsl.so -> libpsl.so.5.3.2
libpsl.so.5 -> libpsl.so.5.3.2
libpsl.so.5.3.2
```