### PR TITLE
Fix windows msvc issues

### DIFF
--- a/fuzz/main.c
+++ b/fuzz/main.c
@@ -41,7 +41,7 @@
 #include <errno.h>
 #include <sys/stat.h>
 
-#if defined (_MSC_VER) && ! defined (ssize_t)
+#if defined(_MSC_VER)
 #include <basetsd.h>
 typedef SSIZE_T ssize_t;
 #endif

--- a/src/psl.c
+++ b/src/psl.c
@@ -56,9 +56,9 @@
 # include <unistd.h>
 #endif
 
-#if defined(_MSC_VER) && ! defined(ssize_t)
+#if defined(_MSC_VER)
 # include <basetsd.h>
-typedef SSIZE_T ssize_t;
+  typedef SSIZE_T ssize_t;
 #endif
 
 #include <stdio.h>

--- a/src/psl.c
+++ b/src/psl.c
@@ -59,12 +59,13 @@
 #if defined(_MSC_VER)
 # include <basetsd.h>
   typedef SSIZE_T ssize_t;
+#else
+# include <strings.h>
 #endif
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <ctype.h>
 #include <time.h>
 #include <errno.h>


### PR DESCRIPTION
ssize_t is never defined as a macro on MSVC

strings.h is not available when building with MSVC

Noticed at: https://gitlab.freedesktop.org/gstreamer/gst-build/issues/84