### PR TITLE
meson: run python script against the meson version of python

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -3,7 +3,7 @@ psl_make_dafsa = find_program('psl-make-dafsa')
 suffixes_dafsa_h = custom_target('suffixes_dafsa.h',
   input : psl_file,
   output : 'suffixes_dafsa.h',
-  command : [psl_make_dafsa, '--output-format=cxx+', '@INPUT@', '@OUTPUT@'])
+  command : [python, psl_make_dafsa, '--output-format=cxx+', '@INPUT@', '@OUTPUT@'])
 
 sources = [
   'lookup_string_in_fixed_set.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,12 +1,12 @@
 psl_dafsa = custom_target('psl.dafsa',
   input : psl_file,
   output : 'psl.dafsa',
-  command : [psl_make_dafsa, '--output-format=binary', '@INPUT@', '@OUTPUT@'])
+  command : [python, psl_make_dafsa, '--output-format=binary', '@INPUT@', '@OUTPUT@'])
 
 psl_ascii_dafsa = custom_target('psl_ascii.dafsa',
   input : psl_file,
   output : 'psl_ascii.dafsa',
-  command : [psl_make_dafsa, '--output-format=binary', '--encoding=ascii', '@INPUT@', '@OUTPUT@'])
+  command : [python, psl_make_dafsa, '--output-format=binary', '--encoding=ascii', '@INPUT@', '@OUTPUT@'])
 
 tests_cargs = [
   '-DHAVE_CONFIG_H',


### PR DESCRIPTION
Avoids using a python that may not exist in a python3 only distribution:

/usr/bin/env: ‘python’: No such file or directory