### PR TITLE
meson: Fix running of psl-make-dafsa on Windows

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,4 @@
-psl_make_dafsa = find_program('psl-make-dafsa')
+psl_make_dafsa = files('psl-make-dafsa')
 
 suffixes_dafsa_h = custom_target('suffixes_dafsa.h',
   input : psl_file,


### PR DESCRIPTION
`find_program()` evaluates to `python psl-make-dafsa` on Windows, so running it with `python` evaluates to `python python psl-make-dafsa`, causing this error on Windows:

```
"c:/python38/python.exe" "python" "C:/projects/repos/libpsl/src/psl-make-dafsa" "--output-format=binary" "C:/projects/repos/libpsl/list/public_suffix_list.dat" "tests/psl.dafsa"
c:/python38/python.exe: can't open file 'python': [Errno 2] No such file or directory
```

Reported at https://gitlab.freedesktop.org/gstreamer/cerbero/-/issues/265.