### PR TITLE
Update Platform.sh example in test_data

### DIFF
--- a/tests/test-is-public-builtin.c
+++ b/tests/test-is-public-builtin.c
@@ -82,8 +82,8 @@ static void test_psl(void)
 		{ ".forgot.his.name", 1, 1 },
 		{ "whoever.his.name", 0, 0 },
 		{ "whoever.forgot.his.name", 0, 0 },
-		{ "whatever.platform.sh", 1, 1 },
-		{ ".platform.sh", 1, 1 },
+		{ "whatever.platformsh.site", 1, 1 },
+		{ ".platformsh.site", 1, 1 },
 		{ "whatever.yokohama.jp", 1, 1 },
 		{ ".yokohama.jp", 1, 1 },
 		{ ".", 1, 0 }, /* special case */


### PR DESCRIPTION
We in Platform.sh worked to remove `*.platform.sh` from PSL, and to replace it with `*.platformsh.site`, our other domain in the PSL. Now our MR to the official PSL would be blocked by failing tests specially due to these entries in `test-is-public-builtin`.