### PR TITLE
Upgrade Ubuntu to fix the coveralls issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: trusty
+dist: xenial
 
 language: c
 


### PR DESCRIPTION
Coveralls fails to report with a cryptic error:

```
requests.exceptions.SSLError: [Errno 1] _ssl.c:510: error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure
```

If I had to guess, I would say that this is [a consequence of the Sectigo certificate expiring on May 30th](https://access.redhat.com/articles/5117881).