### PR TITLE
meson: fix build

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -19,7 +19,7 @@ cargs = [
 libpsl = library('psl', sources, suffixes_dafsa_h,
   include_directories : [configinc, includedir],
   c_args : cargs,
-  dependencies : [libidn2_dep, libidn_dep, libicu_dep, libunistring, networking_deps, libiconv],
+  dependencies : [libidn2_dep, libidn_dep, libicu_dep, libunistring, networking_deps],
   version: lt_version,
   install: true,
 )


### PR DESCRIPTION
src/meson.build:19:0: ERROR: Unknown variable "libiconv".