### PR TITLE
Add WSAStartup() for Windows psl tool and tests.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,7 +20,6 @@ libicu_dep = notfound
 libidn_dep = notfound
 libunistring = notfound
 networking_deps = notfound
-libiconv_dep = notfound
 
 # FIXME: Cleanup this when Meson gets 'feature-combo':
 # https://github.com/mesonbuild/meson/issues/4566
@@ -87,19 +86,6 @@ endif
 if libidn2_dep.found() or libidn_dep.found()
   # Check for libunistring, we need it for psl_str_to_utf8lower()
   libunistring = cc.find_library('unistring')
-  found_iconv = false
-  if cc.has_function('iconv_open')
-    libiconv_dep = []
-    found_iconv = true
-  endif
-  if not found_iconv and cc.has_header_symbol('iconv.h', 'iconv_open')
-    libiconv_dep = [cc.find_library('iconv')]
-    found_iconv = true
-  endif
-
-  if not found_iconv
-    error('iconv implementation not found')
-  endif
 endif
 
 if host_machine.system() == 'windows'

--- a/src/psl.c
+++ b/src/psl.c
@@ -1619,6 +1619,9 @@ static int isip(const char *hostname)
  *
  * Use helper function psl_str_to_utf8lower() for normalization of @hostname and @cookie_domain.
  *
+ * Hint for Windows users:
+ * Please make sure the calling application has called WSAStartup() before calling psl_is_cookie_domain_acceptable().
+ *
  * Examples:
  * 1. Cookie domain 'example.com' would be acceptable for hostname 'www.example.com',
  * but '.com' or 'com' would NOT be acceptable since 'com' is a public suffix.

--- a/tests/test-is-cookie-domain-acceptable.c
+++ b/tests/test-is-cookie-domain-acceptable.c
@@ -32,6 +32,10 @@
 # include <config.h>
 #endif
 
+#ifdef _WIN32
+# include <winsock2.h> // WSAStartup, WSACleanup
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -109,6 +113,18 @@ static void test_psl(void)
 
 int main(int argc, const char * const *argv)
 {
+#ifdef _WIN32
+	WSADATA wsa_data;
+	int err;
+
+	if ((err = WSAStartup(MAKEWORD(2,2), &wsa_data))) {
+		printf("WSAStartup failed with error: %d\n", err);
+		return 1;
+	}
+
+	atexit((void (__cdecl*)(void)) WSACleanup);
+#endif
+
 	/* if VALGRIND testing is enabled, we have to call ourselves with valgrind checking */
 	if (argc == 1) {
 		const char *valgrind = getenv("TESTS_VALGRIND");

--- a/tools/psl.c
+++ b/tools/psl.c
@@ -36,6 +36,10 @@
 # include <unistd.h>
 #endif
 
+#ifdef _WIN32
+# include <winsock2.h> // WSAStartup, WSACleanup
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
@@ -64,6 +68,20 @@ static void usage(int err, FILE* f)
 	fprintf(f, "\n");
 
 	exit(err);
+}
+
+static void init_windows(void) {
+#ifdef _WIN32
+	WSADATA wsa_data;
+	int err;
+
+	if ((err = WSAStartup(MAKEWORD(2,2), &wsa_data))) {
+		printf("WSAStartup failed with error: %d\n", err);
+		exit(EXIT_FAILURE);
+	}
+
+	atexit((void (__cdecl*)(void)) WSACleanup);
+#endif
 }
 
 /* RFC 2822-compliant date format */
@@ -209,6 +227,8 @@ int main(int argc, const char *const *argv)
 				else if (mode == 4) {
 					char *cookie_domain_lower;
 
+					init_windows();
+
 					if ((rc = psl_str_to_utf8lower(domain, NULL, NULL, &cookie_domain_lower)) == PSL_SUCCESS) {
 						if (!batch_mode)
 							printf("%s: ", domain);
@@ -253,6 +273,8 @@ int main(int argc, const char *const *argv)
 		}
 	}
 	else if (mode == 4) {
+		init_windows();
+
 		for (; arg < argv + argc; arg++) {
 			if (!batch_mode)
 				printf("%s: ", *arg);


### PR DESCRIPTION
As reported at https://github.com/rockdaboot/libpsl/issues/173,
psl_is_cookie_domain_acceptable() doesn't work properly without
WSAStartup() on Windows.

Co-authored-by: gvanem@yahoo.no