### PR TITLE
meson: automatically add PSL_STATIC define when building Windows static library and fix tests/tools link errors

### DIFF
--- a/fuzz/meson.build
+++ b/fuzz/meson.build
@@ -15,11 +15,10 @@ foreach test_case : ['fuzzer', 'load_fuzzer', 'load_dafsa_fuzzer']
   endif
   source_file = 'libpsl_@0@.c'.format(test_case)
   exe = executable(test_name, source_file, 'main.c',
-    link_with : libpsl,
     c_args : fuzzer_cargs,
-    include_directories : [configinc, includedir],
-    dependencies : libicu_dep,
-    link_language : link_language
+    include_directories : configinc,
+    link_language : link_language,
+    dependencies : [libpsl_dep, libicu_dep]
   )
   test(test_name, exe)
 endforeach

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,6 +23,17 @@ libtool_version_revision = libtool_version_info[1].to_int()
 libtool_version_age = libtool_version_info[2].to_int()
 library_version = '@0@.@1@.@2@'.format(libtool_version_current - libtool_version_age, libtool_version_age, libtool_version_revision)
 
+interface_cargs = []
+if host_machine.system() == 'windows'
+    default_library = get_option('default_library')
+    if default_library == 'static'
+        interface_cargs = ['-DPSL_STATIC']
+        cargs += interface_cargs
+    elif default_library == 'both'
+        warning('Building both static and dynamic libraries. -DPSL_STATIC will not be added to pkg-config metadata')
+    endif
+endif
+
 libpsl = library('psl', sources, suffixes_dafsa_h,
   include_directories : [configinc, includedir],
   c_args : cargs,
@@ -34,10 +45,12 @@ libpsl = library('psl', sources, suffixes_dafsa_h,
 
 pkgconfig.generate(libpsl,
   name : 'libpsl',
-  description : 'Public Suffix List C library')
+  description : 'Public Suffix List C library',
+  extra_cflags : interface_cargs)
 
 libpsl_dep = declare_dependency(link_with : libpsl,
-  include_directories : includedir)
+  include_directories : includedir,
+  compile_args : interface_cargs)
 
 install_data('psl-make-dafsa', install_dir : get_option('bindir'))
 install_man('psl-make-dafsa.1')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -32,7 +32,8 @@ foreach test_name : tests
   exe = executable(test_name, source,
     c_args : tests_cargs,
     link_with : libpsl,
-    include_directories : [configinc, includedir],
-    link_language : link_language)
+    include_directories : configinc,
+    link_language : link_language,
+    dependencies : [libpsl_dep])
   test(test_name, exe, depends : [psl_dafsa, psl_ascii_dafsa])
 endforeach

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -34,6 +34,6 @@ foreach test_name : tests
     link_with : libpsl,
     include_directories : configinc,
     link_language : link_language,
-    dependencies : [libpsl_dep])
+    dependencies : [libpsl_dep, networking_deps])
   test(test_name, exe, depends : [psl_dafsa, psl_ascii_dafsa])
 endforeach

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -2,7 +2,7 @@ psl = executable('psl', 'psl.c',
   include_directories : configinc,
   c_args : ['-DHAVE_CONFIG_H'],
   link_language : link_language,
-  dependencies : [libpsl_dep],
+  dependencies : [libpsl_dep, networking_deps],
   install : true,
 )
 

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,8 +1,8 @@
 psl = executable('psl', 'psl.c',
-  link_with : libpsl,
-  include_directories : [configinc, includedir],
+  include_directories : configinc,
   c_args : ['-DHAVE_CONFIG_H'],
   link_language : link_language,
+  dependencies : [libpsl_dep],
   install : true,
 )
 


### PR DESCRIPTION
Automatically add PSL_STATIC (including to pkg-config metadata) when building Windows static library (this doesn't work with `--default-library both` and will print a warning).
Also fix linking of tests/tools executables when building Windows shared library by explicitly linking them with ws2_32.