### PR TITLE
Use C++ linker when building with libicu

### DIFF
--- a/fuzz/meson.build
+++ b/fuzz/meson.build
@@ -19,6 +19,7 @@ foreach test_case : ['fuzzer', 'load_fuzzer', 'load_dafsa_fuzzer']
     c_args : fuzzer_cargs,
     include_directories : [configinc, includedir],
     dependencies : libicu_dep,
+    link_language : link_language
   )
   test(test_name, exe)
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,8 @@ libunistring = notfound
 networking_deps = notfound
 libiconv_dep = notfound
 
+link_language = 'c'
+
 # FIXME: Cleanup this when Meson gets 'feature-combo':
 # https://github.com/mesonbuild/meson/issues/4566
 # Dependency fallbacks would help too:
@@ -58,6 +60,11 @@ if ['libicu', 'auto'].contains(enable_runtime) or ['libicu', 'auto'].contains(en
     endif
     if enable_builtin == 'auto'
       enable_builtin = 'libicu'
+    endif
+    if add_languages('cpp', native : false)
+        link_language = 'cpp'
+    else
+        error('C++ compiler is not available')
     endif
   elif [enable_runtime, enable_builtin].contains('libicu')
     error('You requested libicu but it is not installed.')

--- a/src/meson.build
+++ b/src/meson.build
@@ -29,6 +29,7 @@ libpsl = library('psl', sources, suffixes_dafsa_h,
   dependencies : [libidn2_dep, libidn_dep, libicu_dep, libunistring, networking_deps, libiconv_dep],
   version: library_version,
   install: true,
+  link_language : link_language
 )
 
 pkgconfig.generate(libpsl,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -32,6 +32,7 @@ foreach test_name : tests
   exe = executable(test_name, source,
     c_args : tests_cargs,
     link_with : libpsl,
-    include_directories : [configinc, includedir])
+    include_directories : [configinc, includedir],
+    link_language : link_language)
   test(test_name, exe, depends : [psl_dafsa, psl_ascii_dafsa])
 endforeach

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -2,6 +2,7 @@ psl = executable('psl', 'psl.c',
   link_with : libpsl,
   include_directories : [configinc, includedir],
   c_args : ['-DHAVE_CONFIG_H'],
+  link_language : link_language,
   install : true,
 )
 


### PR DESCRIPTION
ICU is a C++ library, event though it has C interface. This means that it depends on C++ standard library internally. When ICU is built as dynamic library we can link to it using C linker without issues because it is already linked to C+ standard library (I'm not sure how portable is this but it works). However, if ICU is built as static library, we must link to C++ standard library manually or use C++ linker, or else we will get linking errors.

This commit does this for Meson. I'm not sure how to do this properly for autotools (I was able to find [this](https://www.gnu.org/software/automake/manual/automake.html#How-the-Linker-is-Chosen) in the automake manual though).