### PR TITLE
Fix "Although the value stored to 'pos' is used in the enclosing expression, the value is never actually read from 'pos'"

### DIFF
--- a/src/psl.c
+++ b/src/psl.c
@@ -936,13 +936,11 @@ static int is_public_suffix(const psl_ctx_t *psl, const char *domain, int type)
 		}
 
 		if ((suffix.label = strchr(suffix.label, '.'))) {
-			int pos;
-
 			suffix.label++;
 			suffix.length = strlen(suffix.label);
 			suffix.nlabels--;
 
-			rule = vector_get(psl->suffixes, (pos = vector_find(psl->suffixes, &suffix)));
+			rule = vector_get(psl->suffixes, vector_find(psl->suffixes, &suffix));
 
 			if (rule) {
 				/* check for correct rule type */


### PR DESCRIPTION
Xcode analyser warning.
![Capture d’écran 2022-10-11 à 17 46 40](https://user-images.githubusercontent.com/839992/195057239-21a177ed-2963-4ab0-9c34-cdca5874bc12.png)
