### PR TITLE
meson: Clean up ICU dependency search

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -40,17 +40,9 @@ if ['libidn2', 'auto'].contains(enable_runtime)
 endif
 
 if ['libicu', 'auto'].contains(enable_runtime)
-  libicu_dep = dependency('icu-uc', required : false)
-  if not libicu_dep.found() and cc.has_header('unicode/ustring.h')
-    # MSVC: the debug configuration of ICU generated the libraries with d suffix
-    # we must handle this and search for the right library depending on the
-    # build type. Note debugoptimized is just a release build with .pdb files enabled
-    if cc.get_id() == 'msvc' and buildtype == 'debug'
-      libicu_dep = cc.find_library('icuucd', required : false)
-    else
-      libicu_dep = cc.find_library('icuuc', required : false)
-    endif
-  endif
+  libicu_dep = dependency('icu-uc', 'ICU',
+                          components: 'uc',
+                          required : false)
   if libicu_dep.found()
     if enable_runtime == 'auto'
       enable_runtime = 'libicu'


### PR DESCRIPTION
Hi,

From the commit message:

<i>Since we are using Meson 0.60.0 or later, use CMake to help us find ICU, which is cleaner and more comprehensive, and allows us to use libicu_dep = depedency(...) even on Visual Studio, where CMake will find the appropriate ICU headers and libraries for us internally.</i>

<i>Sadly, due to peculiarities, we have to live with the warning that comes up as we needed to look for ICU in the older method instead of the recommended modules: ['ICU::uc'] method.</i>

With blessings, thank you!
