### PR TITLE
tools/psl.c: Fix build on Windows

### DIFF
--- a/tools/psl.c
+++ b/tools/psl.c
@@ -38,6 +38,10 @@
 
 #ifdef _WIN32
 # include <winsock2.h> // WSAStartup, WSACleanup
+
+// Windows does not have localtime_r but has localtime_s, which is more or less
+// the same except that the arguments are reversed
+# define localtime_r(t_sec,t_now) localtime_s(t_now,t_sec)
 #endif
 
 #include <stdlib.h>


### PR DESCRIPTION
Hi,

From the commit message:

<i>localtime_r() is not available on Windows but a more-secure variant of localtime(), localtime_s() is provided on Windows.</i>

<i>Define localtime_r() on Windows as its arguments are reversed as compared to localetime_s(), to achive more or less the same purpose.</i>

With blessings, thank you!