### PR TITLE
meson: add support for symbol visibility

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -100,6 +100,9 @@ config.set('HAVE_STRNDUP', cc.has_function('strndup'))
 config.set('HAVE_CLOCK_GETTIME', cc.has_function('clock_gettime'))
 config.set('HAVE_FMEMOPEN', cc.has_function('fmemopen'))
 config.set('HAVE_NL_LANGINFO', cc.has_function('nl_langinfo'))
+if cc.has_function_attribute('visibility')
+  config.set('HAVE_VISIBILITY', 1)
+endif
 configure_file(output : 'config.h', configuration : config)
 
 configinc = include_directories('.')

--- a/src/meson.build
+++ b/src/meson.build
@@ -38,6 +38,7 @@ libpsl = library('psl', sources, suffixes_dafsa_h,
   include_directories : [configinc, includedir],
   c_args : cargs,
   dependencies : [libidn2_dep, libidn_dep, libicu_dep, libunistring, networking_deps, libiconv_dep],
+  gnu_symbol_visibility: 'hidden',
   version: library_version,
   install: true,
   link_language : link_language


### PR DESCRIPTION
libpsl.h can set up a PSL_API macro handling cross-platform symbol hiding/exporting, which depends on indicating that:

- we're currently building the library
- the compiler supports visibility attributes

This avoids leaking symbols and lets the compiler optimize calls.