### PR TITLE
meson: Do not use full_path for file objects

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -13,8 +13,8 @@ tests_cargs = [
   '-DSRCDIR="@0@"'.format(meson.current_source_dir()),
   '-DPSL_FILE="@0@"'.format(psl_file),
   '-DPSL_TESTFILE="@0@"'.format(psl_test_file),
-  '-DPSL_DAFSA="@0@"'.format(psl_dafsa.full_path()),
-  '-DPSL_ASCII_DAFSA="@0@"'.format(psl_ascii_dafsa.full_path()),
+  '-DPSL_DAFSA="@0@"'.format(psl_dafsa),
+  '-DPSL_ASCII_DAFSA="@0@"'.format(psl_ascii_dafsa),
 ]
 
 tests = [


### PR DESCRIPTION
The full path will be inserted automatically here.