### PR TITLE
fix compilation with clang-cl

### DIFF
--- a/src/psl.c
+++ b/src/psl.c
@@ -82,6 +82,8 @@ typedef SSIZE_T ssize_t;
 
 #ifdef HAVE_ALLOCA_H
 #	include <alloca.h>
+#elif defined _WIN32
+#	include <malloc.h>
 #endif
 
 #ifdef WITH_LIBICU

--- a/tests/test-is-public-all.c
+++ b/tests/test-is-public-all.c
@@ -38,6 +38,8 @@
 #include <ctype.h>
 #ifdef HAVE_ALLOCA_H
 #	include <alloca.h>
+#elif defined _WIN32
+#	include <malloc.h>
 #endif
 
 #include <libpsl.h>

--- a/tests/test-is-public-builtin.c
+++ b/tests/test-is-public-builtin.c
@@ -37,6 +37,8 @@
 #include <string.h>
 #ifdef HAVE_ALLOCA_H
 #	include <alloca.h>
+#elif defined _WIN32
+#	include <malloc.h>
 #endif
 
 #include <libpsl.h>

--- a/tests/test-is-public.c
+++ b/tests/test-is-public.c
@@ -37,6 +37,8 @@
 #include <string.h>
 #ifdef HAVE_ALLOCA_H
 #	include <alloca.h>
+#elif defined _WIN32
+#	include <malloc.h>
 #endif
 
 #include <libpsl.h>

--- a/tests/test-registrable-domain.c
+++ b/tests/test-registrable-domain.c
@@ -37,6 +37,8 @@
 #include <string.h>
 #ifdef HAVE_ALLOCA_H
 #	include <alloca.h>
+#elif defined _WIN32
+#	include <malloc.h>
 #endif
 
 #include <libpsl.h>


### PR DESCRIPTION
clang-cl errors on implicit functions. Needs the proper header included.

Fixes https://github.com/rockdaboot/libpsl/issues/216