### PR TITLE
Avoid alloca in libpsl and tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -356,8 +356,6 @@ AC_ARG_WITH(psl-testfile,
   PSL_TESTFILE="\$(top_srcdir)/list/tests/tests.txt")
 AC_SUBST(PSL_TESTFILE)
 
-# check for alloca / alloca.h
-AC_FUNC_ALLOCA
 AC_CHECK_FUNCS([strndup clock_gettime fmemopen nl_langinfo])
 
 # check for dirent.h

--- a/meson.build
+++ b/meson.build
@@ -93,9 +93,7 @@ config.set('WITH_LIBIDN', enable_runtime == 'libidn')
 config.set('ENABLE_BUILTIN', enable_builtin)
 config.set('HAVE_UNISTD_H', cc.check_header('unistd.h'))
 config.set('HAVE_STDINT_H', cc.check_header('stdint.h'))
-config.set('HAVE_ALLOCA_H', cc.check_header('alloca.h'))
 config.set('HAVE_DIRENT_H', cc.check_header('dirent.h'))
-config.set('HAVE_ALLOCA', cc.has_function('alloca'))
 config.set('HAVE_STRNDUP', cc.has_function('strndup'))
 config.set('HAVE_CLOCK_GETTIME', cc.has_function('clock_gettime'))
 config.set('HAVE_FMEMOPEN', cc.has_function('fmemopen'))
@@ -126,9 +124,6 @@ if cc.get_id() == 'msvc'
     if cc.has_header_symbol('stdio.h', '_snprintf')
       add_project_arguments('-Dsnprintf=_snprintf', language: 'c')
     endif
-  endif
-  if cc.has_header_symbol('malloc.h', '_alloca')
-    add_project_arguments('-Dalloca=_alloca', language: 'c')
   endif
 endif
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,12 +15,19 @@ PSL_TESTS = test-is-public test-is-public-all test-is-cookie-domain-acceptable
 
 if ENABLE_BUILTIN
   PSL_TESTS += test-is-public-builtin test-registrable-domain
+  test_is_public_builtin_SOURCES = test-is-public-builtin.c $(common_SOURCES)
+  test_registrable_domain_SOURCES = test-registrable-domain.c $(common_SOURCES)
 endif
 
 check_PROGRAMS = $(PSL_TESTS)
 
 TESTS_ENVIRONMENT = TESTS_VALGRIND="@VALGRIND_ENVIRONMENT@"
 TESTS = $(PSL_TESTS)
+
+common_SOURCES = common.c common.h
+test_is_public_SOURCES = test-is-public.c $(common_SOURCES)
+test_is_public_all_SOURCES = test-is-public-all.c $(common_SOURCES)
+test_is_cookie_domain_acceptable_SOURCES = test-is-cookie-domain-acceptable.c $(common_SOURCES)
 
 # dafsa.psl and dafsa_ascii.psl must be created before any test is executed
 # check-local target works in parallel to the tests, so the test suite will likely fail

--- a/tests/common.c
+++ b/tests/common.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright(c) 2014-2024 Tim Ruehsen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * This file is part of the test suite of libpsl.
+ */
+
+#include <stdio.h> // snprintf
+#include <stdlib.h> // exit, system
+#include <string.h> // strlen
+#if defined _WIN32
+#	include <malloc.h>
+#endif
+
+int run_valgrind(const char *valgrind, const char *executable)
+{
+	char cmd[BUFSIZ];
+	int n, rc;
+
+	n = snprintf(cmd, sizeof(cmd), "TESTS_VALGRIND="" %s %s", valgrind, executable);
+	if ((unsigned)n >= sizeof(cmd)) {
+		printf("Valgrind command line is too long (>= %u)\n", (unsigned) sizeof(cmd));
+		return EXIT_FAILURE;
+	}
+
+	if ((rc = system(cmd))) {
+		printf("Failed to execute with '%s' (system() returned %d)\n", valgrind, rc);
+	}
+
+	return rc ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/common.h
+++ b/tests/common.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright(c) 2014-2024 Tim Ruehsen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * This file is part of the test suite of libpsl.
+ */
+
+#ifndef COMMON_H
+#define COMMON_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int run_valgrind(const char *valgrind, const char *executable);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* COMMON_H */

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -31,8 +31,8 @@ if enable_builtin
 endif
 
 foreach test_name : tests
-  source = test_name + '.c'
-  exe = executable(test_name, source,
+  sources = [test_name + '.c', 'common.c', 'common.h']
+  exe = executable(test_name, sources,
     build_by_default: false,
     c_args : tests_cargs,
     link_with : libpsl,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -30,12 +30,15 @@ if enable_builtin
   tests += ['test-is-public-builtin', 'test-registrable-domain']
 endif
 
+libtestcommon = static_library('testcommon', 'common.c',
+  build_by_default: false)
+
 foreach test_name : tests
   sources = [test_name + '.c', 'common.c', 'common.h']
   exe = executable(test_name, sources,
     build_by_default: false,
     c_args : tests_cargs,
-    link_with : libpsl,
+    link_with : [libpsl, libtestcommon],
     include_directories : configinc,
     link_language : link_language,
     dependencies : [libpsl_dep, networking_deps])

--- a/tests/test-is-cookie-domain-acceptable.c
+++ b/tests/test-is-cookie-domain-acceptable.c
@@ -39,11 +39,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef HAVE_ALLOCA_H
-#	include <alloca.h>
-#endif
 
 #include <libpsl.h>
+#include "common.h"
 
 #define countof(a) (sizeof(a)/sizeof(*(a)))
 
@@ -130,11 +128,7 @@ int main(int argc, const char * const *argv)
 		const char *valgrind = getenv("TESTS_VALGRIND");
 
 		if (valgrind && *valgrind) {
-			size_t cmdsize = strlen(valgrind) + strlen(argv[0]) + 32;
-			char *cmd = alloca(cmdsize);
-
-			snprintf(cmd, cmdsize, "TESTS_VALGRIND="" %s %s", valgrind, argv[0]);
-			return system(cmd) != 0;
+			return run_valgrind(valgrind, argv[0]);
 		}
 	}
 

--- a/tests/test-is-public-all.c
+++ b/tests/test-is-public-all.c
@@ -36,13 +36,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-#ifdef HAVE_ALLOCA_H
-#	include <alloca.h>
-#elif defined _WIN32
+#if defined _WIN32
 #	include <malloc.h>
 #endif
 
 #include <libpsl.h>
+#include "common.h"
 
 static int
 	ok,
@@ -120,7 +119,7 @@ static void test_psl_entry(const psl_ctx_t *psl, const char *domain, int type)
 	} else if (*domain == '*') { /* a wildcard, e.g. *.ck or *.platform.sh */
 		/* '*.platform.sh' -> 'y.x.platform.sh' */
 		size_t len = strlen(domain);
-		char *xdomain = alloca(len + 3);
+		char *xdomain = malloc(len + 3);
 
 		memcpy(xdomain, "y.x", 3);
 		memcpy(xdomain + 3, domain + 1, len);
@@ -129,6 +128,7 @@ static void test_psl_entry(const psl_ctx_t *psl, const char *domain, int type)
 		test_type_any(psl, xdomain + 2, type, 1); /* random wildcard-matching domain is a PS... */
 		test_type_any(psl, xdomain, type, 0); /* ... but sub domain is not */
 
+		free(xdomain);
 	} else {
 		test_type_any(psl, domain, type, 1); /* Any normal PSL entry */
 	}
@@ -230,11 +230,7 @@ int main(int argc, const char * const *argv)
 		const char *valgrind = getenv("TESTS_VALGRIND");
 
 		if (valgrind && *valgrind) {
-			size_t cmdsize = strlen(valgrind) + strlen(argv[0]) + 32;
-			char *cmd = alloca(cmdsize);
-
-			snprintf(cmd, cmdsize, "TESTS_VALGRIND="" %s %s", valgrind, argv[0]);
-			return system(cmd) != 0;
+			return run_valgrind(valgrind, argv[0]);
 		}
 	}
 

--- a/tests/test-is-public-builtin.c
+++ b/tests/test-is-public-builtin.c
@@ -35,13 +35,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef HAVE_ALLOCA_H
-#	include <alloca.h>
-#elif defined _WIN32
-#	include <malloc.h>
-#endif
 
 #include <libpsl.h>
+#include "common.h"
 
 #define countof(a) (sizeof(a)/sizeof(*(a)))
 
@@ -141,11 +137,7 @@ int main(int argc, const char * const *argv)
 		const char *valgrind = getenv("TESTS_VALGRIND");
 
 		if (valgrind && *valgrind) {
-			size_t cmdsize = strlen(valgrind) + strlen(argv[0]) + 32;
-			char *cmd = alloca(cmdsize);
-
-			snprintf(cmd, cmdsize, "TESTS_VALGRIND="" %s %s", valgrind, argv[0]);
-			return system(cmd) != 0;
+			return run_valgrind(valgrind, argv[0]);
 		}
 	}
 

--- a/tests/test-is-public.c
+++ b/tests/test-is-public.c
@@ -35,13 +35,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef HAVE_ALLOCA_H
-#	include <alloca.h>
-#elif defined _WIN32
-#	include <malloc.h>
-#endif
 
 #include <libpsl.h>
+#include "common.h"
 
 #define countof(a) (sizeof(a)/sizeof(*(a)))
 
@@ -195,11 +191,7 @@ int main(int argc, const char * const *argv)
 		const char *valgrind = getenv("TESTS_VALGRIND");
 
 		if (valgrind && *valgrind) {
-			size_t cmdsize = strlen(valgrind) + strlen(argv[0]) + 32;
-			char *cmd = alloca(cmdsize);
-
-			snprintf(cmd, cmdsize, "TESTS_VALGRIND="" %s %s", valgrind, argv[0]);
-			return system(cmd) != 0;
+			return run_valgrind(valgrind, argv[0]);
 		}
 	}
 

--- a/tests/test-registrable-domain.c
+++ b/tests/test-registrable-domain.c
@@ -35,13 +35,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef HAVE_ALLOCA_H
-#	include <alloca.h>
-#elif defined _WIN32
-#	include <malloc.h>
-#endif
 
 #include <libpsl.h>
+#include "common.h"
 
 static int
 	ok,
@@ -199,11 +195,7 @@ int main(int argc, const char * const *argv)
 		const char *valgrind = getenv("TESTS_VALGRIND");
 
 		if (valgrind && *valgrind) {
-			size_t cmdsize = strlen(valgrind) + strlen(argv[0]) + 32;
-			char *cmd = alloca(cmdsize);
-
-			snprintf(cmd, cmdsize, "TESTS_VALGRIND="" %s %s", valgrind, argv[0]);
-			return system(cmd) != 0;
+			return run_valgrind(valgrind, argv[0]);
 		}
 	}
 


### PR DESCRIPTION
`alloca()` needs special treatment for Windows and possibly other systems. The implementation also is compiler-specific. `alloca()` in general is considered "dangerous" (similar to variable-length arrays (VLAs)).

This PR drops the usage of `alloca()` for the aforementioned reasons.
