### PR TITLE
Replace strcasecmp() with isUTF8()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -363,9 +363,6 @@ AC_CHECK_FUNCS([strndup clock_gettime fmemopen nl_langinfo])
 # check for dirent.h
 AC_HEADER_DIRENT
 
-# strings.h may not exist on WIN32
-AC_CHECK_HEADERS([strings.h])
-
 # Override the template file name of the generated .pc file, so that there
 # is no need to rename the template file when the API version changes.
 AC_CONFIG_FILES([Makefile

--- a/src/psl.c
+++ b/src/psl.c
@@ -64,9 +64,6 @@ typedef SSIZE_T ssize_t;
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef HAVE_STRINGS_H
-# include <strings.h>
-#endif
 #include <ctype.h>
 #include <time.h>
 #include <errno.h>
@@ -331,6 +328,14 @@ static int suffix_init(psl_entry_t *suffix, const char *rule, size_t length)
 	*dst = 0;
 
 	return 0;
+}
+
+/* Avoid using strcasecmp() or _stricmp() */
+static int isUTF8(const char *s) {
+	return (s[0] == 'u' || s[0] == 'U')
+		&& (s[1] == 't' || s[1] == 'T')
+		&& (s[2] == 'f' || s[2] == 'F')
+		&& s[3] == '-' && s[4] == 0;
 }
 
 #if !defined(WITH_LIBIDN) && !defined(WITH_LIBIDN2) && !defined(WITH_LIBICU)
@@ -1827,7 +1832,7 @@ out:
 		}
 
 		/* convert to UTF-8 */
-		if (strcasecmp(encoding, "utf-8")) {
+		if (!isUTF8(encoding)) {
 			iconv_t cd = iconv_open("utf-8", encoding);
 
 			if (cd != (iconv_t)-1) {


### PR DESCRIPTION
This change increases portability as some libc / compiler combinations doesn't know about strcasecmp(). 