### PR TITLE
meson: simplify python3 detection

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -116,7 +116,7 @@ if psl_test_file == ''
   psl_test_file = join_paths(meson.current_source_dir(), 'list', 'tests', 'tests.txt')
 endif
 
-python = import('python').find_installation()
+python = find_program('python3')
 pkgconfig = import('pkgconfig')
 
 if cc.get_id() == 'msvc'


### PR DESCRIPTION
Don't look up the python module's find_installation() method. This is intended for detecting lots of information needed for compiling and installing python modules including the C-API interface to libpython, as well as site-packages layout information.

It's totally uninvolved with what we are doing, which is executing a script. For this, we just need any python program. Meson is written in python3, so we know in meson.build that we have that available -- which is also why meson guarantees that `find_program('python3')` always returns a valid python. Even if no python is installed on the system, meson will return the `meson.exe runpython` shim which runs the script using the copy of python bundled inside the redistributable meson Windows executable.