### PR TITLE
Add configure flag --with-libunistring-prefix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,9 @@ AC_C_INLINE
 dnl Check for visibility support
 gl_VISIBILITY
 
+dnl Unicodesupport
+gl_LIBUNISTRING
+
 #
 # Generate version defines for include file
 #

--- a/m4/absolute-header.m4
+++ b/m4/absolute-header.m4
@@ -1,0 +1,100 @@
+# absolute-header.m4 serial 18
+dnl Copyright (C) 2006-2024 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+
+dnl From Derek Price.
+
+# gl_ABSOLUTE_HEADER(HEADER1 HEADER2 ...)
+# ---------------------------------------
+# Find the absolute name of a header file, testing first if the header exists.
+# If the header were sys/inttypes.h, this macro would define
+# ABSOLUTE_SYS_INTTYPES_H to the '""' quoted absolute name of sys/inttypes.h
+# in config.h
+# (e.g. '#define ABSOLUTE_SYS_INTTYPES_H "///usr/include/sys/inttypes.h"').
+# The three "///" are to pacify Sun C 5.8, which otherwise would say
+# "warning: #include of /usr/include/... may be non-portable".
+# Use '""', not '<>', so that the /// cannot be confused with a C99 comment.
+# Note: This macro assumes that the header file is not empty after
+# preprocessing, i.e. it does not only define preprocessor macros but also
+# provides some type/enum definitions or function/variable declarations.
+AC_DEFUN([gl_ABSOLUTE_HEADER],
+[AC_REQUIRE([AC_CANONICAL_HOST])
+AC_LANG_PREPROC_REQUIRE()dnl
+m4_foreach_w([gl_HEADER_NAME], [$1],
+  [AS_VAR_PUSHDEF([gl_absolute_header],
+                  [gl_cv_absolute_]m4_defn([gl_HEADER_NAME]))dnl
+  AC_CACHE_CHECK([absolute name of <]m4_defn([gl_HEADER_NAME])[>],
+    [gl_absolute_header],
+    [AS_VAR_PUSHDEF([ac_header_exists],
+                    [ac_cv_header_]m4_defn([gl_HEADER_NAME]))dnl
+    AC_CHECK_HEADERS_ONCE(m4_defn([gl_HEADER_NAME]))dnl
+    if test AS_VAR_GET([ac_header_exists]) = yes; then
+      gl_ABSOLUTE_HEADER_ONE(m4_defn([gl_HEADER_NAME]))
+    fi
+    AS_VAR_POPDEF([ac_header_exists])dnl
+    ])dnl
+  AC_DEFINE_UNQUOTED(AS_TR_CPP([ABSOLUTE_]m4_defn([gl_HEADER_NAME])),
+                     ["AS_VAR_GET([gl_absolute_header])"],
+                     [Define this to an absolute name of <]m4_defn([gl_HEADER_NAME])[>.])
+  AS_VAR_POPDEF([gl_absolute_header])dnl
+])dnl
+])# gl_ABSOLUTE_HEADER
+
+# gl_ABSOLUTE_HEADER_ONE(HEADER)
+# ------------------------------
+# Like gl_ABSOLUTE_HEADER, except that:
+#   - it assumes that the header exists,
+#   - it uses the current CPPFLAGS,
+#   - it does not cache the result,
+#   - it is silent.
+AC_DEFUN([gl_ABSOLUTE_HEADER_ONE],
+[
+  AC_REQUIRE([AC_CANONICAL_HOST])
+  AC_LANG_CONFTEST([AC_LANG_SOURCE([[#include <]]m4_dquote([$1])[[>]])])
+  dnl AIX "xlc -E" and "cc -E" omit #line directives for header files
+  dnl that contain only a #include of other header files and no
+  dnl non-comment tokens of their own. This leads to a failure to
+  dnl detect the absolute name of <dirent.h>, <signal.h>, <poll.h>
+  dnl and others. The workaround is to force preservation of comments
+  dnl through option -C. This ensures all necessary #line directives
+  dnl are present. GCC supports option -C as well.
+  case "$host_os" in
+    aix*) gl_absname_cpp="$ac_cpp -C" ;;
+    *)    gl_absname_cpp="$ac_cpp" ;;
+  esac
+changequote(,)
+  case "$host_os" in
+    mingw* | windows*)
+      dnl For the sake of native Windows compilers (excluding gcc),
+      dnl treat backslash as a directory separator, like /.
+      dnl Actually, these compilers use a double-backslash as
+      dnl directory separator, inside the
+      dnl   # line "filename"
+      dnl directives.
+      gl_dirsep_regex='[/\\]'
+      ;;
+    *)
+      gl_dirsep_regex='\/'
+      ;;
+  esac
+  dnl A sed expression that turns a string into a basic regular
+  dnl expression, for use within "/.../".
+  gl_make_literal_regex_sed='s,[]$^\\.*/[],\\&,g'
+  gl_header_literal_regex=`echo '$1' \
+                           | sed -e "$gl_make_literal_regex_sed"`
+  gl_absolute_header_sed="/${gl_dirsep_regex}${gl_header_literal_regex}/"'{
+      s/.*"\(.*'"${gl_dirsep_regex}${gl_header_literal_regex}"'\)".*/\1/
+      s|^/[^/]|//&|
+      p
+      q
+    }'
+changequote([,])
+  dnl eval is necessary to expand gl_absname_cpp.
+  dnl Ultrix and Pyramid sh refuse to redirect output of eval,
+  dnl so use subshell.
+  AS_VAR_SET([gl_cv_absolute_]AS_TR_SH([[$1]]),
+[`(eval "$gl_absname_cpp conftest.$ac_ext") 2>&AS_MESSAGE_LOG_FD |
+  sed -n "$gl_absolute_header_sed"`])
+])

--- a/m4/libunistring.m4
+++ b/m4/libunistring.m4
@@ -1,0 +1,143 @@
+# libunistring.m4 serial 13
+dnl Copyright (C) 2009-2024 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+
+AC_PREREQ([2.64])
+
+dnl gl_LIBUNISTRING
+dnl Searches for an installed libunistring.
+dnl If found, it sets and AC_SUBSTs HAVE_LIBUNISTRING=yes and the LIBUNISTRING
+dnl and LTLIBUNISTRING variables, sets the LIBUNISTRING_VERSION variable, and
+dnl augments the CPPFLAGS variable, and #defines HAVE_LIBUNISTRING to 1.
+dnl Otherwise, it sets and AC_SUBSTs HAVE_LIBUNISTRING=no and LIBUNISTRING and
+dnl LTLIBUNISTRING to empty.
+
+dnl Define gl_LIBUNISTRING using AC_DEFUN_ONCE, in order dnl to avoid warnings
+dnl like
+dnl "warning: AC_REQUIRE: `gl_LIBUNISTRING' was expanded before it was required".
+dnl This is tricky because of the way 'aclocal' is implemented:
+dnl - It requires defining an auxiliary macro whose name ends in AC_DEFUN.
+dnl   Otherwise aclocal's initial scan pass would miss the macro definition.
+dnl - It requires a line break inside the AC_DEFUN_ONCE and AC_DEFUN expansions.
+dnl   Otherwise aclocal would emit many "Use of uninitialized value $1"
+dnl   warnings.
+AC_DEFUN_ONCE([gl_LIBUNISTRING],
+[
+  AC_BEFORE([$0], [gl_LIBUNISTRING_MODULE])
+  AC_BEFORE([$0], [gl_LIBUNISTRING_LIBHEADER])
+  AC_BEFORE([$0], [gl_LIBUNISTRING_LIB_PREPARE])
+
+  m4_ifdef([gl_LIBUNISTRING_OPTIONAL],
+    [
+      AC_MSG_CHECKING([whether included libunistring is requested])
+      AC_ARG_WITH([included-libunistring],
+        [  --with-included-libunistring  use the libunistring parts included here],
+        [gl_libunistring_force_included=$withval],
+        [gl_libunistring_force_included=no])
+      AC_MSG_RESULT([$gl_libunistring_force_included])
+      gl_libunistring_use_included="$gl_libunistring_force_included"
+      if test "$gl_libunistring_use_included" = yes; then
+        dnl Assume that libunistring is not installed until some other macro
+        dnl explicitly invokes gl_LIBUNISTRING_CORE.
+        if test -z "$HAVE_LIBUNISTRING"; then
+          HAVE_LIBUNISTRING=no
+        fi
+        LIBUNISTRING=
+        LTLIBUNISTRING=
+      else
+        gl_LIBUNISTRING_CORE
+        if test $HAVE_LIBUNISTRING = no; then
+          gl_libunistring_use_included=yes
+          LIBUNISTRING=
+          LTLIBUNISTRING=
+        fi
+      fi
+    ],
+    [gl_LIBUNISTRING_CORE])
+])
+
+AC_DEFUN([gl_LIBUNISTRING_CORE],
+[
+  AC_REQUIRE([AM_ICONV])
+  if test -n "$LIBICONV"; then
+    dnl First, try to link without -liconv. libunistring often depends on
+    dnl libiconv, but we don't know (and often don't need to know) where
+    dnl libiconv is installed.
+    AC_LIB_HAVE_LINKFLAGS([unistring], [],
+      [#include <uniconv.h>], [u8_strconv_from_locale((char*)0);],
+      [no, trying again together with libiconv])
+    if test "$ac_cv_libunistring" != yes; then
+      dnl Second try, with -liconv.
+      dnl We have to erase the cached result of the first AC_LIB_HAVE_LINKFLAGS
+      dnl invocation, otherwise the second one will not be run.
+      unset ac_cv_libunistring
+      glus_saved_LIBS="$LIBS"
+      LIBS="$LIBS $LIBICONV"
+      AC_LIB_HAVE_LINKFLAGS([unistring], [],
+        [#include <uniconv.h>], [u8_strconv_from_locale((char*)0);],
+        [no, consider installing GNU libunistring])
+      if test -n "$LIBUNISTRING"; then
+        LIBUNISTRING="$LIBUNISTRING $LIBICONV"
+        LTLIBUNISTRING="$LTLIBUNISTRING $LTLIBICONV"
+      fi
+      LIBS="$glus_saved_LIBS"
+    fi
+  else
+    AC_LIB_HAVE_LINKFLAGS([unistring], [],
+      [#include <uniconv.h>], [u8_strconv_from_locale((char*)0);],
+      [no, consider installing GNU libunistring])
+  fi
+  if test $HAVE_LIBUNISTRING = yes; then
+    dnl Determine the installed version.
+    AC_CACHE_CHECK([for libunistring version], [gl_cv_libunistring_version],
+      [AC_COMPUTE_INT([gl_libunistring_hexversion],
+                      [_LIBUNISTRING_VERSION],
+                      [#include <unistring/version.h>])
+       dnl Versions <= 0.9.3 had a hexversion of 0x0009.
+       dnl Use other tests to distinguish them.
+       if test $gl_libunistring_hexversion = 9; then
+         dnl Version 0.9.2 introduced the header <unistring/cdefs.h>.
+         AC_COMPILE_IFELSE(
+           [AC_LANG_PROGRAM([[#include <unistring/cdefs.h>]], [[]])],
+           [gl_cv_libunistring_version092=true],
+           [gl_cv_libunistring_version092=false])
+         if $gl_cv_libunistring_version092; then
+           dnl Version 0.9.3 changed a comment in <unistr.h>.
+           gl_ABSOLUTE_HEADER_ONE([unistr.h])
+           if test -n "$gl_cv_absolute_unistr_h" \
+              && grep 'Copy no more than N units of SRC to DEST.  Return a pointer' $gl_cv_absolute_unistr_h > /dev/null; then
+             dnl Detected version 0.9.3.
+             gl_libunistring_hexversion=2307
+           else
+             dnl Detected version 0.9.2.
+             gl_libunistring_hexversion=2306
+           fi
+         else
+           dnl Version 0.9.1 introduced the type casing_suffix_context_t.
+           AC_COMPILE_IFELSE(
+             [AC_LANG_PROGRAM(
+                [[#include <unicase.h>
+                  casing_suffix_context_t ct;]],
+                [[]])],
+             [gl_cv_libunistring_version091=true],
+             [gl_cv_libunistring_version091=false])
+           if $gl_cv_libunistring_version091; then
+             dnl Detected version 0.9.1.
+             gl_libunistring_hexversion=2305
+           else
+             dnl Detected version 0.9.
+             gl_libunistring_hexversion=2304
+           fi
+         fi
+       fi
+       dnl Transform into the usual major.minor.subminor notation.
+       gl_libunistring_major=`expr $gl_libunistring_hexversion / 65536`
+       gl_libunistring_minor=`expr $gl_libunistring_hexversion / 256 % 256`
+       gl_libunistring_subminor=`expr $gl_libunistring_hexversion % 256`
+       gl_cv_libunistring_version="$gl_libunistring_major.$gl_libunistring_minor.$gl_libunistring_subminor"
+      ])
+    LIBUNISTRING_VERSION="$gl_cv_libunistring_version"
+  fi
+])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,7 +11,7 @@ lib_LTLIBRARIES = libpsl.la
 libpsl_la_SOURCES = $(LIBPSL_SRCS)
 libpsl_la_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include -DPSL_DISTFILE=\"$(PSL_DISTFILE)\" \
   $(CFLAG_VISIBILITY) -DBUILDING_PSL
-libpsl_la_LIBADD = $(LTLIBICONV) $(LTLIBINTL) @INTL_MACOSX_LIBS@
+libpsl_la_LIBADD = $(LTLIBUNISTRING) $(LTLIBICONV) $(LTLIBINTL) @INTL_MACOSX_LIBS@
 
 # include ABI version information
 libpsl_la_LDFLAGS = -no-undefined -version-info $(LIBPSL_SO_VERSION)


### PR DESCRIPTION
Fixes #214

@TurtleWilly @rb07 Can you test this please?

It looks like it works for me:
```
$ ./configure --enable-runtime=libidn2 --with-libunistring-prefix=/tmp
...
$ make
...
$ ldd tests/test-is-public
        linux-vdso.so.1 (0x00007ffd4179a000)
        libpsl.so.5 => /home/tim/src/libpsl/src/.libs/libpsl.so.5 (0x00007f2440e2c000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f2440c2d000)
        libunistring.so.5 => /tmp/lib/libunistring.so.5 (0x00007f2440a70000)
        libidn2.so.0 => /lib/x86_64-linux-gnu/libidn2.so.0 (0x00007f2440a3d000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f2440e46000)
```