### PR TITLE
Add Libs.private to autoconf libpsl.pc

### DIFF
--- a/libpsl.pc.in
+++ b/libpsl.pc.in
@@ -8,4 +8,5 @@ Description: Public Suffix List C library.
 Version: @PACKAGE_VERSION@
 URL: @PACKAGE_URL@
 Libs: -L${libdir} -lpsl
+Libs.private: @LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
Static libraries don't include dependency information, so when using pkg-config to find out how to link with a static library, the .pc file for that library has to specify what other libraries to link. Libs.private is like Libs, except it's only used when static linking. This fixes linking against a static libpsl using pkg-config.

The Meson-generated libpsl.pc just includes all of its dependent libraries in Libs, so doesn't require any additional fix.