### PR TITLE
Support icu provided by Windows

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -54,7 +54,10 @@ jobs:
       fail-fast: true
       max-parallel: 3
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        os: ['ubuntu-latest', 'macos-latest']
+        include:
+          - os: 'windows-latest'
+            extra_meson_args: '--vsenv'
     steps:
     - name: Check out
       uses: actions/checkout@v7
@@ -72,8 +75,8 @@ jobs:
         echo "LIBRARY_PATH=$(brew --prefix)/lib:$LIBRARY_PATH" >> $GITHUB_ENV
         echo "CPATH=$(brew --prefix)/include:$CPATH" >> $GITHUB_ENV
     - name: Configure
-      run: meson setup builddir
+      run: meson setup builddir ${{matrix.extra_meson_args}}
     - name: Build
-      run: ninja -C builddir
+      run: meson compile -C builddir
     - name: Test
       run: meson test -C builddir --print-errorlogs

--- a/fuzz/libpsl_fuzzer.c
+++ b/fuzz/libpsl_fuzzer.c
@@ -35,8 +35,12 @@ typedef unsigned __int8 uint8_t;
 #include <stdlib.h> /* malloc, free */
 #include <string.h> /* memcpy */
 
-#if defined(WITH_LIBICU)
+#ifdef WITH_LIBICU
+#ifndef WITH_LIBICU_WIN
 #include <unicode/uclean.h>
+#else
+#include <icu.h>
+#endif
 #endif
 
 #include "libpsl.h"

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,7 @@ notfound = dependency('', required : false)
 libidn2_dep = notfound
 libicu_dep = notfound
 libicucore_dep = notfound
+libicu_win_dep = notfound
 libidn_dep = notfound
 libunistring = notfound
 networking_deps = notfound
@@ -30,6 +31,17 @@ if enable_runtime == 'libicucore' or (host_machine.system() == 'darwin' and enab
     endif
   elif enable_runtime == 'libicucore'
     error('You requested libicucore but it is not available.')
+  endif
+endif
+
+if enable_runtime == 'libicu-win' or (host_machine.system() == 'windows' and enable_runtime == 'auto')
+  libicu_win_dep = cc.find_library('icu', has_headers : ['icu.h'], required: false)
+  if libicu_win_dep.found()
+    if enable_runtime == 'auto'
+      enable_runtime = 'libicu-win'
+    endif
+  elif enable_runtime == 'libicu-win'
+    error('You requested libicu-win but it is not available.')
   endif
 endif
 
@@ -104,6 +116,7 @@ config.set_quoted('PACKAGE_VERSION', meson.project_version())
 config.set('WITH_LIBIDN2', enable_runtime == 'libidn2')
 config.set('WITH_LIBICU', enable_runtime == 'libicu')
 config.set('WITH_LIBICUCORE', enable_runtime == 'libicucore')
+config.set('WITH_LIBICU_WIN', enable_runtime == 'libicu-win')
 config.set('WITH_LIBIDN', enable_runtime == 'libidn')
 config.set('ENABLE_BUILTIN', enable_builtin)
 config.set('HAVE_UNISTD_H', cc.check_header('unistd.h'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,5 @@
 option('runtime', type : 'combo',
-  choices : ['libidn2', 'libicu', 'libicucore', 'libidn', 'no', 'auto'], value : 'auto',
+  choices : ['libidn2', 'libicu', 'libicucore', 'libicu-win', 'libidn', 'no', 'auto'], value : 'auto',
   description : 'Specify the IDNA library used for libpsl run-time conversions')
 
 option('builtin', type : 'boolean',

--- a/src/meson.build
+++ b/src/meson.build
@@ -37,7 +37,7 @@ endif
 libpsl = library('psl', sources, suffixes_dafsa_h,
   include_directories : [configinc, includedir],
   c_args : cargs,
-  dependencies : [libidn2_dep, libidn_dep, libicu_dep, libicucore_dep, libunistring, networking_deps, libiconv_dep],
+  dependencies : [libidn2_dep, libidn_dep, libicu_dep, libicucore_dep, libicu_win_dep, libunistring, networking_deps, libiconv_dep],
   gnu_symbol_visibility: 'hidden',
   version: library_version,
   install: true,

--- a/src/psl.c
+++ b/src/psl.c
@@ -104,6 +104,8 @@ typedef SSIZE_T ssize_t;
 #	include <unicode/uversion.h>
 #	include <unicode/ustring.h>
 #	include <unicode/uidna.h>
+#elif defined(WITH_LIBICU_WIN)
+# include <icu.h>
 #elif defined(WITH_LIBIDN2)
 #	include <iconv.h>
 #	include <idn2.h>
@@ -354,7 +356,7 @@ static char *psl_strdup(const char *s)
 	return strcpy(p, s);
 }
 
-#if !defined(WITH_LIBIDN) && !defined(WITH_LIBIDN2) && !defined(WITH_LIBICU) && !defined(WITH_LIBICUCORE)
+#if !defined(WITH_LIBIDN) && !defined(WITH_LIBIDN2) && !defined(WITH_LIBICU) && !defined(WITH_LIBICUCORE) && !defined(WITH_LIBICU_WIN)
 /*
  * When configured without runtime IDNA support (./configure --disable-runtime), we need a pure ASCII
  * representation of non-ASCII characters in labels as found in UTF-8 domain names.
@@ -688,7 +690,7 @@ typedef void *psl_idna_t;
 
 static psl_idna_t *psl_idna_open(void)
 {
-#if defined(WITH_LIBICU) || defined(WITH_LIBICUCORE)
+#if defined(WITH_LIBICU) || defined(WITH_LIBICUCORE) || defined(WITH_LIBICU_WIN)
 	UErrorCode status = 0;
 	return (void *)uidna_openUTS46(UIDNA_USE_STD3_RULES | UIDNA_NONTRANSITIONAL_TO_ASCII, &status);
 #endif
@@ -699,7 +701,7 @@ static void psl_idna_close(psl_idna_t *idna)
 {
 	(void) idna;
 
-#if defined(WITH_LIBICU) || defined(WITH_LIBICUCORE)
+#if defined(WITH_LIBICU) || defined(WITH_LIBICUCORE) || defined(WITH_LIBICU_WIN)
 	if (idna)
 		uidna_close((UIDNA *)idna);
 #endif
@@ -709,7 +711,7 @@ static int psl_idna_toASCII(psl_idna_t *idna, const char *utf8, char **ascii)
 {
 	int ret = -1;
 
-#if defined(WITH_LIBICU) || defined(WITH_LIBICUCORE)
+#if defined(WITH_LIBICU) || defined(WITH_LIBICUCORE) || defined(WITH_LIBICU_WIN)
 	(void) idna;
 
 	/* IDNA2008 UTS#46 punycode conversion */
@@ -1582,6 +1584,8 @@ const char *psl_get_version(void)
 	return PACKAGE_VERSION " (+libicu/" U_ICU_VERSION ")";
 #elif defined(WITH_LIBICUCORE)
 	return PACKAGE_VERSION " (+libicucore/" U_ICU_VERSION ")";
+#elif defined(WITH_LIBICU_WIN)
+	return PACKAGE_VERSION " (+icu.lib/Windows)";
 #elif defined(WITH_LIBIDN2)
 	return PACKAGE_VERSION " (+libidn2/" IDN2_VERSION ")";
 #elif defined(WITH_LIBIDN)
@@ -1928,7 +1932,7 @@ psl_error_t psl_str_to_utf8lower(const char *str, const char *encoding, const ch
 		return PSL_SUCCESS;
 	}
 
-#ifdef WITH_LIBICU
+#if defined(WITH_LIBICU) || defined(WITH_LIBICU_WIN)
 #define STACK_STRLENGTH 256
 	do {
 	UErrorCode status = 0;

--- a/tests/test-registrable-domain.c
+++ b/tests/test-registrable-domain.c
@@ -55,7 +55,7 @@ static void testx(const psl_ctx_t *psl, const char *domain, const char *encoding
 	if ((rc = psl_str_to_utf8lower(domain, encoding, lang, &lower)) == PSL_SUCCESS)
 		domain = lower;
 	/* non-ASCII domains fail here if no runtime IDN library is configured, so skip it */
-#if defined(WITH_LIBIDN) || defined(WITH_LIBIDN2) || defined(WITH_LIBICU)
+#if defined(WITH_LIBIDN) || defined(WITH_LIBIDN2) || defined(WITH_LIBICU) || defined(WITH_LIBICUCORE) || defined(WITH_LIBICU_WIN)
 	else if (domain) {
 		/* if we do not runtime support, test failure have to be skipped */
 		failed++;
@@ -111,7 +111,7 @@ static void test_psl(void)
 	test(NULL, "com", NULL);
 
 	/* Norwegian with uppercase oe */
-#ifdef WITH_LIBICU
+#if defined(WITH_LIBICU) || defined(WITH_LIBICUCORE) || defined(WITH_LIBICU_WIN)
 	test(psl, "www.\303\230yer.no", "www.\303\270yer.no");
 #endif
 
@@ -120,7 +120,7 @@ static void test_psl(void)
 
 	/* Norwegian with lowercase oe, encoded as ISO-8859-15 */
         /* makes only sense with a runtime IDN library configured */
-#if defined(WITH_LIBIDN) || defined(WITH_LIBIDN2) || defined(WITH_LIBICU)
+#if defined(WITH_LIBIDN) || defined(WITH_LIBIDN2) || defined(WITH_LIBICU) || defined(WITH_LIBICUCORE) || defined(WITH_LIBICU_WIN)
 	test_iso(psl, "www.\370yer.no", "www.\303\270yer.no");
 #endif
 


### PR DESCRIPTION
Windows provided `icu.lib` since [Windows 10 Version 1903](https://learn.microsoft.com/en-us/windows/win32/intl/international-components-for-unicode--icu-#version-1903-may-2019-update).