### PR TITLE
Adding a basic CMakeLists for building a static library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: "Build"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    name: Cmake
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: true
+      matrix:
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          # no dependencies
+
+      - name: Configure
+        run: |
+          cmake -S . -B builddir
+
+      - name: Build
+        run: |
+          cmake --build builddir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,66 @@
+# Note: this isn't a full CMakeLists.txt for this project.
+# This is just building a static library.
+
+cmake_minimum_required(VERSION 3.10)
+
+set(VERSION 0.21.5) # must match version.txt
+set(VERSION_NUMBER 0x001505) # must match version.txt converted to hexadecimal
+
+project(psl
+  VERSION ${VERSION}
+  LANGUAGES C
+  DESCRIPTION "C library to handle the Public Suffix List"
+)
+set(LIBPSL_VERSION_NUMBER ${VERSION_NUMBER})
+set(LIBPSL_VERSION_MAJOR ${psl_VERSION_MAJOR})
+set(LIBPSL_VERSION_MINOR ${psl_VERSION_MINOR})
+set(LIBPSL_VERSION_PATCH ${psl_VERSION_PATCH})
+set(LIBPSL_VERSION "${psl_VERSION_MAJOR}.${psl_VERSION_MINOR}.${psl_VERSION_PATCH}")
+
+add_definitions(
+  -DPACKAGE_VERSION=\"${LIBPSL_VERSION}\"
+  -DBUILDING_PSL=1
+  -DPSL_STATIC=1
+  # ensure that builtin list is enabled
+  -DENABLE_BUILTIN=1
+)
+
+set(PSL_FILE "${CMAKE_SOURCE_DIR}/list/public_suffix_list.dat")
+
+find_program(
+  PYTHON python
+  NAMES python2 python3 python3.7
+  HINTS /usr/pkg/bin
+  REQUIRED
+)
+add_custom_target(
+  "suffixes_dafsa.h"
+  ALL
+  "${PYTHON}"
+  "${CMAKE_SOURCE_DIR}/src/psl-make-dafsa"
+  --output-format=cxx+
+  "${PSL_FILE}"
+  "${CMAKE_BINARY_DIR}/suffixes_dafsa.h"
+)
+
+configure_file(
+  "${CMAKE_SOURCE_DIR}/include/libpsl.h.in"
+  "${CMAKE_BINARY_DIR}/libpsl.h"
+)
+
+add_library(${PROJECT_NAME} STATIC
+  src/lookup_string_in_fixed_set.c
+  src/psl.c
+)
+
+include_directories(
+  "${CMAKE_BINARY_DIR}"
+)
+
+add_dependencies(
+  "${PROJECT_NAME}"
+  "suffixes_dafsa.h"
+)
+
+install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+install(FILES "${CMAKE_BINARY_DIR}/libpsl.h" DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,13 +17,31 @@ set(LIBPSL_VERSION_MINOR ${psl_VERSION_MINOR})
 set(LIBPSL_VERSION_PATCH ${psl_VERSION_PATCH})
 set(LIBPSL_VERSION "${psl_VERSION_MAJOR}.${psl_VERSION_MINOR}.${psl_VERSION_PATCH}")
 
+set(LIBPSL_STANDALONE_BUILD OFF)
+if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(LIBPSL_STANDALONE_BUILD ON)
+endif()
+option(LIBPSL_ENABLE_INSTALL "${PROJECT_NAME}: Enable install" ${LIBPSL_STANDALONE_BUILD})
+
+option(ENABLE_BUILTIN "Generate built-in PSL data" ON)
+set(ENABLE_RUNTIME "" CACHE STRING "Enable runtime PSL data (libicu, libidn, libidn2)")
+
 add_definitions(
   -DPACKAGE_VERSION=\"${LIBPSL_VERSION}\"
-  -DBUILDING_PSL=1
-  -DPSL_STATIC=1
-  # ensure that builtin list is enabled
-  -DENABLE_BUILTIN=1
 )
+
+if(ENABLE_BUILTIN)
+  add_definitions(-DENABLE_BUILTIN=1)
+endif()
+if(ENABLE_RUNTIME STREQUAL "libicu")
+  add_definitions(-DWITH_LIBICU=1)
+endif()
+if(ENABLE_RUNTIME STREQUAL "libidn")
+  add_definitions(-DWITH_LIBIDN=1)
+endif()
+if(ENABLE_RUNTIME STREQUAL "libidn2")
+  add_definitions(-DWITH_LIBIDN2=1)
+endif()
 
 set(PSL_FILE "${CMAKE_SOURCE_DIR}/list/public_suffix_list.dat")
 
@@ -62,5 +80,8 @@ add_dependencies(
   "suffixes_dafsa.h"
 )
 
-install(TARGETS ${PROJECT_NAME} DESTINATION lib)
-install(FILES "${CMAKE_BINARY_DIR}/libpsl.h" DESTINATION include)
+if(LIBPSL_ENABLE_INSTALL)
+  install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+  install(FILES "${CMAKE_BINARY_DIR}/libpsl.h" DESTINATION include)
+endif()
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libpsl.pc
 
-EXTRA_DIST = build-aux/config.rpath LICENSE meson.build  meson_options.txt
+EXTRA_DIST = build-aux/config.rpath CMakeLists.txt LICENSE meson.build  meson_options.txt
 dist-hook:
 	mkdir -p $(distdir)/list/tests
 	cp -p $(PSL_FILE) $(distdir)/list

--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ Prerequisites:
 There is also an unofficial MSVC nmake build configuration in `msvc/`.   Please
 see README.MSVC.md on building libpsl with Visual Studio via NMake or Meson.
 
+### Building with `cmake`
+
+This only builds the static library libpsl.a.
+
+		cmake -S . -B builddir
+		cmake --build builddir
 
 ## Mailing List
 


### PR DESCRIPTION
Based on @ckerr code at https://github.com/transmission/libpsl/blob/692c69d2415e1b20378030c08607935a54434087/CMakeLists.txt

Adapted for upstream.

Added a cross-platforms workflow to trigger it on each pull request (ubuntu, windows, macos).