### PR TITLE
Allow building from tarball without Python

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,10 @@ AC_ARG_ENABLE([man],
 AM_CONDITIONAL(ENABLE_MAN, test x$enable_man = xyes)
 
 # src/psl-make-dafsa needs python 2.7+
-AM_PATH_PYTHON([2.7])
+AS_IF([! test -f src/suffixes_dafsa.h -a -f tests/psl.dafsa -a -f tests/psl_ascii.dafsa],
+  [
+    AM_PATH_PYTHON([2.7],, [AC_MSG_ERROR([python 2.7+ is required to convert the PSL data])])
+  ])
 
 PKG_PROG_PKG_CONFIG
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,8 +3,9 @@ include libpsl-srcs.mk
 # suffixes.c must be created before psl.c is compiled
 BUILT_SOURCES = suffixes_dafsa.h
 
-# suffixes.c is a built source that must be cleaned
-CLEANFILES = suffixes_dafsa.h
+# suffixes.c is a built source that a normal clean should not touch.
+# Because building it is expensive and requires python to be installed.
+MAINTAINERCLEANFILES = suffixes_dafsa.h
 
 lib_LTLIBRARIES = libpsl.la
 
@@ -23,6 +24,6 @@ suffixes_dafsa.h: $(PSL_FILE) $(srcdir)/psl-make-dafsa
 
 bin_SCRIPTS = psl-make-dafsa
 
-EXTRA_DIST = psl-make-dafsa LICENSE.chromium meson.build
+EXTRA_DIST = psl-make-dafsa LICENSE.chromium meson.build suffixes_dafsa.h
 
 dist_man_MANS = psl-make-dafsa.1

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,8 +2,8 @@ DEFS = @DEFS@ \
        -DSRCDIR=\"$(srcdir)\" \
        -DPSL_FILE=\"$(PSL_FILE)\" \
        -DPSL_TESTFILE=\"$(PSL_TESTFILE)\" \
-       -DPSL_DAFSA=\"psl.dafsa\" \
-       -DPSL_ASCII_DAFSA=\"psl_ascii.dafsa\"
+       -DPSL_DAFSA=\"$(srcdir)/psl.dafsa\" \
+       -DPSL_ASCII_DAFSA=\"$(srcdir)/psl_ascii.dafsa\"
 AM_CPPFLAGS = -I$(top_srcdir)/include
 LDADD = ../src/libpsl.la
 AM_LDFLAGS = -no-install
@@ -37,7 +37,7 @@ psl.dafsa: $(PSL_FILE)
 psl_ascii.dafsa: $(PSL_FILE)
 	$(PYTHON) $(top_srcdir)/src/psl-make-dafsa --output-format=binary --encoding=ascii "$(PSL_FILE)" psl_ascii.dafsa
 
-clean-local:
-	rm -f psl.dafsa psl_ascii.dafsa
+MAINTAINERCLEANFILES = psl.dafsa psl_ascii.dafsa
 
-EXTRA_DIST = meson.build
+# Add the dafsa files because building them is expensive and requires python to be installed.
+EXTRA_DIST = meson.build psl.dafsa psl_ascii.dafsa

--- a/tests/test-is-public-all.c
+++ b/tests/test-is-public-all.c
@@ -149,16 +149,16 @@ static void test_psl(void)
 	printf("builtin PSL has %d suffixes and %d exceptions\n", psl_suffix_count(psl2), psl_suffix_exception_count(psl2));
 
 	if (!(psl3 = psl_load_file(PSL_DAFSA))) {
-		fprintf(stderr, "Failed to load 'psl.dafsa'\n");
+		fprintf(stderr, "Failed to load '%s'\n", PSL_DAFSA);
 		failed++;
 	}
 
 	if (!(psl4 = psl_load_file(PSL_ASCII_DAFSA))) {
-		fprintf(stderr, "Failed to load 'psl_ascii.dafsa'\n");
+		fprintf(stderr, "Failed to load '%s'\n", PSL_ASCII_DAFSA);
 		failed++;
 	}
 
-	psl5 = psl_latest("psl.dafsa");
+	psl5 = psl_latest(PSL_DAFSA);
 
 	if ((fp = fopen(PSL_FILE, "r"))) {
 #ifdef HAVE_CLOCK_GETTIME


### PR DESCRIPTION
This adds the DAFSA files to the tarball, which allows building without installing python.
It allows, for example, to reduce the size of build container images.
