### PR TITLE
Updated stat sys function call support on Windows

### DIFF
--- a/src/psl.c
+++ b/src/psl.c
@@ -38,6 +38,16 @@
 #       define GCC_VERSION_AT_LEAST(major, minor) 0
 #endif
 
+/* Must be defined before <sys/stat.h> */
+#if defined(_MSC_VER) || defined(__MINGW32__)
+# define USE_WIN32_LARGE_FILES
+# ifdef __MINGW32__
+#   ifndef _FILE_OFFSET_BITS
+#    define _FILE_OFFSET_BITS 64
+#   endif
+# endif
+#endif
+
 #include <sys/types.h>
 #include <sys/stat.h>
 
@@ -46,6 +56,21 @@
 # define WIN32_LEAN_AND_MEAN
 # endif
 # include <windows.h> /* for GetACP() */
+#endif
+
+#if defined(_WIN32)
+# ifdef USE_WIN32_LARGE_FILES
+#  define struct_stat  struct _stati64
+#  define func_sys_stat _stati64
+# else
+#  define struct_stat  struct _stat
+#  define func_sys_stat _stat
+# endif
+#endif
+
+#ifndef struct_stat
+# define struct_stat   struct stat
+# define func_sys_stat stat
 #endif
 
 #if defined(_MSC_VER) && ! defined(ssize_t)
@@ -1512,9 +1537,9 @@ const char *psl_builtin_filename(void)
  */
 int psl_builtin_outdated(void)
 {
-	struct stat st;
+	struct_stat st;
 
-	if (stat(_psl_filename, &st) == 0 && st.st_mtime > _psl_file_time)
+	if (func_sys_stat(_psl_filename, &st) == 0 && st.st_mtime > _psl_file_time)
 		return 1;
 
 	return 0;
@@ -1983,10 +2008,10 @@ out:
 /* if file is newer than the builtin data, insert it reverse sorted by mtime */
 static int insert_file(const char *fname, const char **psl_fname, time_t *psl_mtime, int n)
 {
-	struct stat st;
+	struct_stat st;
 	int it;
 
-	if (fname && *fname && stat(fname, &st) == 0 && st.st_mtime > _psl_file_time) {
+	if (fname && *fname && func_sys_stat(fname, &st) == 0 && st.st_mtime > _psl_file_time) {
 		/* add file name and mtime to end of array */
 		psl_fname[n] = fname;
 		psl_mtime[n++] = st.st_mtime;


### PR DESCRIPTION
Following https://github.com/rockdaboot/libpsl/issues/256.

## Why?

I propose a quick patch to directly use crt function _stat() on Windows platform instead of the interface provided by MinGW to avoid breaking compatibility with change in MinGW versions.
As stat() function signature didn't change, it's only a rework of the abstract interface of MinGW who cause a compatibility issue (and not a change in the CRT).

## Regression testing

I've tested the changes in this PR using `make check` on a Ubuntu 22.04 platform with GCC-14 for native linux and with GCC-14 MinGW-w64 13 in cross-compilation.
Plus I tested on a test program directly on Windows using GCC-14 MinGW-w64 **12** natively.

## What does this patch involve?

This patch only change the stat() and struct stat redirection from MinGW to direct CRT (similar to how libcurl does it) only on Windows build. The linux sys/stat() is keep untouched.
The stat() symbol in the otutput .a lib on linux is still `stat`.
On Windows, the previous glitch generated a `stat64` symbol, which [aren't pushed in the tagged v13](https://github.com/mingw-w64/mingw-w64/issues/135#issuecomment-3541489769) of MinGW.
Now, with this patch, the symbol is `_imp__stat64` instead and use the Windows UCRT .dll directly.