### PR TITLE
Improve MSVC support with Autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -213,6 +213,12 @@ AC_SUBST([AM_CPPFLAGS])
 AC_SUBST([AM_CFLAGS])
 AC_SUBST([AM_LDFLAGS])
 
+dnl If we are building only static libraries, we need to define PSL_STATIC
+dnl when building psl executable; this is required on Windows since libpsl
+dnl uses __declspec(dllimport) by default.
+AS_IF([test "x${enable_shared}" = "xno"],
+  [AS_VAR_APPEND([AM_CPPFLAGS], [" -DPSL_STATIC"])])
+
 dnl We use pkg-config/pkgconf to find dependencies. We want to ensure that we
 dnl are able to find them even if they are installed as static libraries only.
 dnl

--- a/configure.ac
+++ b/configure.ac
@@ -297,9 +297,17 @@ if test "$enable_runtime" = "auto"; then
   enable_runtime=no
 fi
 
-dnl If we use libidn or libidn2, we also need libunistring
+dnl If we use libidn or libidn2, we also need libiconv and libunistring
 if test "x$enable_runtime" = "xlibidn2" -o "x$enable_runtime" = "xlibidn"; then
   __save_LIBS=$LIBS
+
+  LIBS=$LIBICONV
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([#include <iconv.h>], [iconv_open ("", "");])
+  ], [:], [
+    AC_MSG_ERROR([You requested libidn2|libidn but libiconv is not installed.])
+  ])
+  LIBS=$__save_LIBS
 
   LIBS=$LIBUNISTRING
   AC_LINK_IFELSE([

--- a/configure.ac
+++ b/configure.ac
@@ -190,6 +190,19 @@ if test "$enable_builtin" = "yes"; then
   AC_DEFINE([ENABLE_BUILTIN], [1], [Generate built-in PSL data])
 fi
 
+dnl Global project-specific compiler and linker flags.
+dnl
+dnl We should not use plain *FLAGS since they belong to the user.
+dnl We can temporary modify them for configuration checks, but then we need to
+dnl restore them to their original values.
+AM_CPPFLAGS="-I\$(top_builddir)/include -I\$(top_srcdir)/include"
+AM_CFLAGS=
+AM_LDFLAGS=
+
+AC_SUBST([AM_CPPFLAGS])
+AC_SUBST([AM_CFLAGS])
+AC_SUBST([AM_LDFLAGS])
+
 if test "$enable_runtime" = "libidn2" -o "$enable_runtime" = "auto"; then
   # Check for libidn2
   PKG_CHECK_MODULES([LIBIDN2], [libidn2], [

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,12 @@ AC_C_INLINE
 dnl Check for visibility support
 gl_VISIBILITY
 
+dnl Solaris has socket in libsocket and inet_ntop in libnsl, but also needs
+dnl libsocket, so the order is important here
+AC_CHECK_LIB([socket], [socket], [
+  AC_CHECK_LIB([nsl], [inet_ntop], [:], [:])
+], [:])
+
 dnl AM_ICONV sets @LIBICONV@ and @LTLIBICONV@ for use in Makefile.am
 dnl libunistring may depend on libiconv, so invoke it before gl_LIBUNISTRING
 AM_ICONV
@@ -322,19 +328,6 @@ AM_CONDITIONAL([WITH_LIBICU], test "x$enable_runtime" = "xlibicu")
 AM_CONDITIONAL([WITH_LIBIDN2], test "x$enable_runtime" = "xlibidn2")
 AM_CONDITIONAL([WITH_LIBIDN], test "x$enable_runtime" = "xlibidn")
 AM_CONDITIONAL([ENABLE_BUILTIN], test "x$enable_builtin" = "xyes")
-
-# Solaris has socket in libsocket and inet_ntop in libnsl, but also needs libsocket, so the order is important here
-AC_CHECK_LIB([socket], [socket], [NEEDS_SOCKET=yes], [])
-if test -n "$NEEDS_SOCKET" ; then
-  AC_CHECK_LIB([nsl], [inet_ntop], [NEEDS_NSL=yes], [])
-fi
-if test -n "$NEEDS_SOCKET" && test -n "$NEEDS_NSL" ; then
-  LIBS="$LIBS -lsocket -lnsl"
-elif test -n "$NEEDS_SOCKET" ; then
-  LIBS="$LIBS -lsocket"
-elif test -n "$NEEDS_NSL" ; then
-  LIBS="$LIBS -lnsl"
-fi
 
 # Check for clock_gettime() used for performance measurement
 AC_SEARCH_LIBS(clock_gettime, rt)

--- a/configure.ac
+++ b/configure.ac
@@ -213,87 +213,259 @@ AC_SUBST([AM_CPPFLAGS])
 AC_SUBST([AM_CFLAGS])
 AC_SUBST([AM_LDFLAGS])
 
+dnl We use pkg-config/pkgconf to find dependencies. We want to ensure that we
+dnl are able to find them even if they are installed as static libraries only.
+dnl
+dnl If we were able to locate package using PKG_CHECK_MODULES, try to do a
+dnl link test to ensure that we can link against it. This may fail because only
+dnl static library is available but we did not add private libraries
+dnl (Libs.private) or compiler flags (Cflags.private).
+dnl
+dnl If we failed to link against library found with PKG_CHECK_MODULES, try
+dnl to use PKG_CHECK_MODULES_STATIC to obtain compiler and linker flags
+dnl required to link against static library.
+
+dnl Compiler flags required to use $enable_runtime (when != "no")
+runtime_CFLAGS=
+dnl Libraries required to use $enable_runitme (when != "no")
+runtime_LIBS=
+
+AC_SUBST([runtime_CFLAGS])
+AC_SUBST([runtime_LIBS])
+
+dnl Check for libidn2
 if test "$enable_runtime" = "libidn2" -o "$enable_runtime" = "auto"; then
-  # Check for libidn2
-  PKG_CHECK_MODULES([LIBIDN2], [libidn2], [
-    HAVE_LIBIDN2=yes
-    if test "$enable_runtime" = "libidn2" -o "$enable_runtime" = "auto"; then
-      LIBS="$LIBIDN2_LIBS $LIBS"
-      CFLAGS="$LIBIDN2_CFLAGS $CFLAGS"
-    fi
-  ], [
-    AC_SEARCH_LIBS(idn2_lookup_u8, idn2, HAVE_LIBIDN2=yes,
-    [
-       if test "$enable_runtime" = "libidn2"; then
-          AC_MSG_ERROR(You requested libidn2 but it is not installed.)
-       fi
-    ], -lunistring)
+  HAVE_LIBIDN2=no
+
+  # Save CFLAGS and LIBS so we can restore them later
+  __save_CFLAGS=$CFLAGS
+  __save_LIBS=$LIBS
+
+  m4_define([LIBIDN2_LINK_TEST], [AC_LANG_PROGRAM(
+    [extern char idn2_lookup_u8 (void);],
+    [idn2_lookup_u8();]
+  )])
+
+  PKG_CHECK_MODULES([LIBIDN2], [libidn2], [HAVE_LIBIDN2=maybe], [HAVE_LIBIDN2=no])
+
+  # Check if we can link against libidn2
+  AS_IF([test "x$HAVE_LIBIDN2" = xmaybe], [
+    CFLAGS="$LIBIDN2_CFLAGS $CFLAGS"
+    LIBS="$LIBIDN2_LIBS $LIBS"
+    AC_LINK_IFELSE([
+      LIBIDN2_LINK_TEST
+    ], [
+      HAVE_LIBIDN2=yes
+    ], [
+      AC_MSG_NOTICE([located libidn2 but cannot link... trying static linking])
+      LIBIDN2_CFLAGS=
+      LIBIDN2_LIBS=
+      CFLAGS=$__save_CFLAGS
+      LIBS=$__save_LIBS
+    ])
   ])
 
+  # If we cannot link against found libidn2, try static linking
+  AS_IF([test "x$HAVE_LIBIDN2" = xmaybe], [
+    PKG_CHECK_MODULES_STATIC([LIBIDN2], [libidn2], [
+      CFLAGS="$LIBIDN2_CFLAGS $CFLAGS"
+      LIBS="$LIBIDN2_LIBS $LIBS"
+      AC_LINK_IFELSE([
+        LIBIDN2_LINK_TEST
+      ], [
+        HAVE_LIBIDN2=yes
+        AC_MSG_NOTICE([using static libidn2])
+      ], [
+        HAVE_LIBIDN2=no
+        AC_MSG_NOTICE([libidn2 is installed but unusable])
+        LIBIDN2_CFLAGS=
+        LIBIDN2_LIBS=
+        CFLAGS=$__save_CFLAGS
+        LIBS=$__save_LIBS
+      ])
+    ], [
+      HAVE_LIBIDN2=no
+    ])
+  ])
+
+  CFLAGS=$__save_CFLAGS
+  LIBS=$__save_LIBS
+
   if test "x$HAVE_LIBIDN2" = "xyes"; then
+    runtime_CFLAGS=$LIBIDN2_CFLAGS
+    runtime_LIBS=$LIBIDN2_LIBS
+
     if test "$enable_runtime" = "auto"; then
       enable_runtime=libidn2
       AC_DEFINE([WITH_LIBIDN2], [1], [generate PSL data using libidn2])
     fi
+  else
+    if test "$enable_runtime" = "libidn2"; then
+      AC_MSG_ERROR([You requested libidn2 but it is not installed or usable.])
+    fi
   fi
 fi
 
+dnl Check for libicu
 if test "$enable_runtime" = "libicu" -o "$enable_runtime" = "auto"; then
-  # Check for libicu
+  HAVE_LIBICU=no
+
+  # Save CFLAGS and LIBS so we can restore them later
+  __save_CFLAGS=$CFLAGS
+  __save_LIBS=$LIBS
+
+  m4_define([ICU_LINK_TEST], [AC_LANG_PROGRAM(
+    [[#include <unicode/ustring.h>]],
+    [[u_strToUTF8(NULL, 0, NULL, NULL, 0, NULL);]]
+  )])
+
   # using pkg-config won't work on older systems like Ubuntu 12.04 LTS Server Edition 64bit
   # using AC_SEARCH_LIBS also don't work since functions have the library version appended
-  PKG_CHECK_MODULES([LIBICU], [icu-uc], [
-    HAVE_LIBICU=yes
-    if test "$enable_runtime" = "libicu" -o "$enable_runtime" = "auto"; then
-      LIBS="$LIBICU_LIBS $LIBS"
-      CFLAGS="$LIBICU_CFLAGS $CFLAGS"
-    fi
-  ], [
-    OLDLIBS=$LIBS
-    LIBS="-licuuc $LIBS"
-    AC_MSG_CHECKING([for ICU unicode library])
-    AC_LINK_IFELSE(
-      [AC_LANG_PROGRAM(
-        [[#include <unicode/ustring.h>]],
-        [[u_strToUTF8(NULL, 0, NULL, NULL, 0, NULL);]])],
-      [HAVE_LIBICU=yes; LIBICU_LIBS="-licuuc"; AC_MSG_RESULT([yes])],
-      [ AC_MSG_RESULT([no]);
-        if test "$enable_runtime" = "libicu"; then
-          AC_MSG_ERROR(You requested libicu but it is not installed.)
-        fi
-        LIBS=$OLDLIBS
-      ])
+  PKG_CHECK_MODULES([LIBICU], [icu-uc], [HAVE_LIBICU=maybe], [HAVE_LIBICU=no])
+
+  # Check if we can link against libicu
+  AS_IF([test "x$HAVE_LIBICU" = xmaybe], [
+    CFLAGS="$LIBICU_CFLAGS $CFLAGS"
+    LIBS="$LIBICU_LIBS $LIBS"
+    AC_LINK_IFELSE([
+      ICU_LINK_TEST
+    ], [
+      HAVE_LIBICU=yes
+    ], [
+      AC_MSG_NOTICE([located libicu but cannot link... trying static linking])
+      LIBICU_CFLAGS=
+      LIBICU_LIBS=
+      CFLAGS=$__save_CFLAGS
+      LIBS=$__save_LIBS
+    ])
   ])
 
+  # If we cannot link against found libicu, try static linking
+  AS_IF([test "x$HAVE_LIBICU" = xmaybe], [
+    PKG_CHECK_MODULES_STATIC([LIBICU], [icu-uc], [
+      CFLAGS="$LIBICU_CFLAGS $CFLAGS"
+      LIBS="$LIBICU_LIBS $LIBS"
+      AC_LINK_IFELSE([
+        ICU_LINK_TEST
+      ], [
+        HAVE_LIBICU=yes
+        AC_MSG_NOTICE([using static libicu])
+      ], [
+        HAVE_LIBICU=no
+        AC_MSG_NOTICE([libicu is installed but unusable])
+        LIBICU_CFLAGS=
+        LIBICU_LIBS=
+        CFLAGS=$__save_CFLAGS
+        LIBS=$__save_LIBS
+      ])
+    ], [
+      HAVE_LIBICU=no
+    ])
+  ])
+
+  # Try -licuuc
+  AS_IF([test "x$HAVE_LIBICU" = xno], [
+    AC_MSG_CHECKING([for ICU unicode library])
+    LIBS="-licuuc $LIBS"
+    AC_LINK_IFELSE([
+      ICU_LINK_TEST
+    ], [
+      HAVE_LIBICU=yes
+      LIBICU_LIBS='-licuuc'
+    ], [
+      HAVE_LIBICU=no
+      LIBS=$__save_LIBS
+    ])
+    AC_MSG_RESULT([$HAVE_LIBICU])
+  ])
+
+  CFLAGS=$__save_CFLAGS
+  LIBS=$__save_LIBS
+
   if test "x$HAVE_LIBICU" = "xyes"; then
+    runtime_CFLAGS=$LIBICU_CFLAGS
+    runtime_LIBS=$LIBICU_LIBS
+
     if test "$enable_runtime" = "auto"; then
       enable_runtime=libicu
       AC_DEFINE([WITH_LIBICU], [1], [generate PSL data using libicu])
     fi
+  else
+    if test "$enable_runtime" = "libicu"; then
+      AC_MSG_ERROR([You requested libicu but it is not installed or usable.])
+    fi
   fi
 fi
 
+dnl Checl for libidn
 if test "$enable_runtime" = "libidn" -o "$enable_runtime" = "auto"; then
-  # Check for libidn
-  PKG_CHECK_MODULES([LIBIDN], [libidn], [
-    HAVE_LIBIDN=yes
-    if test "$enable_runtime" = "libidn" -o "$enable_runtime" = "auto"; then
-      LIBS="$LIBIDN_LIBS $LIBS"
-      CFLAGS="$LIBIDN_CFLAGS $CFLAGS"
-    fi
-  ], [
-    AC_SEARCH_LIBS(idna_to_ascii_8z, idn, HAVE_LIBIDN=yes,
-    [
-      if test "$enable_runtime" = "libidn"; then
-        AC_MSG_ERROR(You requested libidn but it is not installed.)
-      fi
+  HAVE_LIBIDN=no
+
+  # Save CFLAGS and LIBS so we can restore them later
+  __save_CFLAGS=$CFLAGS
+  __save_LIBS=$LIBS
+
+  m4_define([LIBIDN_LINK_TEST], [AC_LANG_PROGRAM(
+    [extern char idna_to_ascii_8z (void);],
+    [idna_to_ascii_8z();]
+  )])
+
+  PKG_CHECK_MODULES([LIBIDN], [libidn], [HAVE_LIBIDN=maybe], [HAVE_LIBIDN=no])
+
+  # Check if we can link against libidn
+  AS_IF([test "x$HAVE_LIBIDN" = xmaybe], [
+    CFLAGS="$LIBIDN_CFLAGS $CFLAGS"
+    LIBS="$LIBIDN_LIBS $LIBS"
+    AC_LINK_IFELSE([
+      LIBIDN_LINK_TEST
+    ], [
+      HAVE_LIBIDN=yes
+    ], [
+      AC_MSG_NOTICE([located libidn but cannot link... trying static linking])
+      LIBIDN_CFLAGS=
+      LIBIDN_LIBS=
+      CFLAGS=$__save_CFLAGS
+      LIBS=$__save_LIBS
     ])
   ])
 
+  # If we cannot link against found libidn, try static linking
+  AS_IF([test "x$HAVE_LIBIDN" = xmaybe], [
+    PKG_CHECK_MODULES_STATIC([LIBIDN], [libidn], [
+      CFLAGS="$LIBIDN_CFLAGS $CFLAGS"
+      LIBS="$LIBIDN_LIBS $LIBS"
+      AC_LINK_IFELSE([
+        LIBIDN_LINK_TEST
+      ], [
+        HAVE_LIBIDN=yes
+        AC_MSG_NOTICE([using static libidn])
+      ], [
+        HAVE_LIBIDN=no
+        AC_MSG_NOTICE([libidn is installed but unusable])
+        LIBIDN_CFLAGS=
+        LIBIDN_LIBS=
+        CFLAGS=$__save_CFLAGS
+        LIBS=$__save_LIBS
+      ])
+    ], [
+      HAVE_LIBIDN=no
+    ])
+  ])
+
+  CFLAGS=$__save_CFLAGS
+  LIBS=$__save_LIBS
+
   if test "x$HAVE_LIBIDN" = "xyes"; then
+    runtime_CFLAGS=$LIBIDN_CFLAGS
+    runtime_LIBS=$LIBIDN_LIBS
+
     if test "$enable_runtime" = "auto"; then
       enable_runtime=libidn
       AC_DEFINE([WITH_LIBIDN], [1], [generate PSL data using libidn])
+    fi
+  else
+    if test "$enable_runtime" = "libidn"; then
+      AC_MSG_ERROR([You requested libidn but it is not installed or usable.])
     fi
   fi
 fi
@@ -322,6 +494,8 @@ if test "x$enable_runtime" = "xlibidn2" -o "x$enable_runtime" = "xlibidn"; then
     AC_MSG_ERROR([You requested libidn2|libidn but libunistring is not installed.])
   ])
   LIBS=$__save_LIBS
+
+  runtime_LIBS="$runtime_LIBS $LTLIBUNISTRING $LTLIBICONV"
 fi
 
 AM_CONDITIONAL([WITH_LIBICU], test "x$enable_runtime" = "xlibicu")

--- a/configure.ac
+++ b/configure.ac
@@ -576,6 +576,21 @@ else
   TESTS_INFO="Valgrind testing not enabled"
 fi
 
+dnl Normally, tests/psl.dafsa and tests/psl_ascii.dafsa are distributed with
+dnl source code. When doing out-of-tree build from git checkout, they will be
+dnl generated in builddir. Make sure we support both cases.
+PSL_DAFSA=$srcdir/tests/psl.dafsa
+PSL_ASCII_DAFSA=$srcdir/tests/psl_ascii.dafsa
+
+AS_IF([test ! -f "$PSL_DAFSA"], [
+  PSL_DAFSA="\$(top_builddir)/tests/psl.dafsa]")
+
+AS_IF([test ! -f "$PSL_ASCII_DAFSA"], [
+  PSL_ASCII_DAFSA="\$(top_builddir)/tests/psl_ascii.dafsa"])
+
+AC_SUBST([PSL_DAFSA])
+AC_SUBST([PSL_ASCII_DAFSA])
+
 # Check for distribution-wide PSL file
 AC_ARG_WITH(psl-distfile,
   AS_HELP_STRING([--with-psl-distfile=[PATH]], [path to distribution-wide PSL file]),

--- a/configure.ac
+++ b/configure.ac
@@ -309,6 +309,8 @@ fi
 dnl Check for libicu
 if test "$enable_runtime" = "libicu" -o "$enable_runtime" = "auto"; then
   HAVE_LIBICU=no
+  # Whether we found libicu using pkg-config
+  HAVE_LIBICU_PC=no
 
   # Save CFLAGS and LIBS so we can restore them later
   __save_CFLAGS=$CFLAGS
@@ -321,7 +323,12 @@ if test "$enable_runtime" = "libicu" -o "$enable_runtime" = "auto"; then
 
   # using pkg-config won't work on older systems like Ubuntu 12.04 LTS Server Edition 64bit
   # using AC_SEARCH_LIBS also don't work since functions have the library version appended
-  PKG_CHECK_MODULES([LIBICU], [icu-uc], [HAVE_LIBICU=maybe], [HAVE_LIBICU=no])
+  PKG_CHECK_MODULES([LIBICU], [icu-uc], [
+    HAVE_LIBICU_PC=yes
+    HAVE_LIBICU=maybe
+  ], [
+    HAVE_LIBICU=no
+  ])
 
   # Check if we can link against libicu
   AS_IF([test "x$HAVE_LIBICU" = xmaybe], [
@@ -351,6 +358,7 @@ if test "$enable_runtime" = "libicu" -o "$enable_runtime" = "auto"; then
         HAVE_LIBICU=yes
         AC_MSG_NOTICE([using static libicu])
       ], [
+        HAVE_LIBICU_PC=no
         HAVE_LIBICU=no
         AC_MSG_NOTICE([libicu is installed but unusable])
         LIBICU_CFLAGS=
@@ -502,6 +510,42 @@ AM_CONDITIONAL([WITH_LIBICU], test "x$enable_runtime" = "xlibicu")
 AM_CONDITIONAL([WITH_LIBIDN2], test "x$enable_runtime" = "xlibidn2")
 AM_CONDITIONAL([WITH_LIBIDN], test "x$enable_runtime" = "xlibidn")
 AM_CONDITIONAL([ENABLE_BUILTIN], test "x$enable_builtin" = "xyes")
+
+dnl libpsl.pc
+libpsl_pc_Cflags=
+libpsl_pc_Cflags_private=
+libpsl_pc_Libs=
+libpsl_pc_Libs_private=
+libpsl_pc_Requires=
+libpsl_pc_Requires_private=
+
+if test "$enable_runtime" = libidn2; then
+  libpsl_pc_Libs_private="$LTLIBUNISTRING $LTLIBICONV $LIBS"
+  libpsl_pc_Requires_private=libidn2
+elif test "$enable_runtime" = libidn; then
+  libpsl_pc_Libs_private="$LTLIBUNISTRING $LTLIBICONV $LIBS"
+  libpsl_pc_Requires_private=libidn
+elif test "$enable_runtime" = libicu; then
+  if test "x$HAVE_LIBICU_PC" = xyes; then
+    libpsl_pc_Libs_private="$LIBS"
+    libpsl_pc_Requires_private=icu-uc
+  else
+    libpsl_pc_Libs_private="$LIBICU_LIBS $LIBS"
+  fi
+fi
+
+dnl On Windows we use pkgconf-specific Cflags.private to pass -DPSL_STATIC
+AS_CASE([${host}],
+  [*-mingw32 | *-mingw64 | *-windows], [
+    libpsl_pc_Cflags_private='Cflags.private: -DPSL_STATIC'
+    libpsl_pc_Requires='pkgconf'])
+
+AC_SUBST([libpsl_pc_Cflags])
+AC_SUBST([libpsl_pc_Cflags_private])
+AC_SUBST([libpsl_pc_Libs])
+AC_SUBST([libpsl_pc_Libs_private])
+AC_SUBST([libpsl_pc_Requires])
+AC_SUBST([libpsl_pc_Requires_private])
 
 # Check for clock_gettime() used for performance measurement
 AC_SEARCH_LIBS(clock_gettime, rt)

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,11 @@ AC_C_INLINE
 dnl Check for visibility support
 gl_VISIBILITY
 
-dnl Unicodesupport
+dnl AM_ICONV sets @LIBICONV@ and @LTLIBICONV@ for use in Makefile.am
+dnl libunistring may depend on libiconv, so invoke it before gl_LIBUNISTRING
+AM_ICONV
+
+dnl Unicode support
 gl_LIBUNISTRING
 
 #
@@ -297,10 +301,6 @@ if test "x$HAVE_LIBIDN2" = "xyes" -o "x$HAVE_LIBIDN" = "xyes"; then
   # Check for libunistring, we need it for psl_str_to_utf8lower()
   AC_SEARCH_LIBS(u8_tolower, unistring, HAVE_UNISTRING=yes, AC_MSG_ERROR(You requested libidn2|libidn but libunistring is not installed.))
 fi
-
-# AM_ICONV sets @LIBICONV@ and @LTLIBICONV@ for use in Makefile.am
-# do not use AM_ICONV conditionally
-AM_ICONV
 
 AM_CONDITIONAL([WITH_LIBICU], test "x$enable_runtime" = "xlibicu")
 AM_CONDITIONAL([WITH_LIBIDN2], test "x$enable_runtime" = "xlibidn2")

--- a/configure.ac
+++ b/configure.ac
@@ -297,9 +297,17 @@ if test "$enable_runtime" = "auto"; then
   enable_runtime=no
 fi
 
-if test "x$HAVE_LIBIDN2" = "xyes" -o "x$HAVE_LIBIDN" = "xyes"; then
-  # Check for libunistring, we need it for psl_str_to_utf8lower()
-  AC_SEARCH_LIBS(u8_tolower, unistring, HAVE_UNISTRING=yes, AC_MSG_ERROR(You requested libidn2|libidn but libunistring is not installed.))
+dnl If we use libidn or libidn2, we also need libunistring
+if test "x$enable_runtime" = "xlibidn2" -o "x$enable_runtime" = "xlibidn"; then
+  __save_LIBS=$LIBS
+
+  LIBS=$LIBUNISTRING
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([char u8_tolower (void);], [u8_tolower ();])
+  ], [:], [
+    AC_MSG_ERROR([You requested libidn2|libidn but libunistring is not installed.])
+  ])
+  LIBS=$__save_LIBS
 fi
 
 AM_CONDITIONAL([WITH_LIBICU], test "x$enable_runtime" = "xlibicu")

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = @AM_CPPFLAGS@ -I$(srcdir) -DSRCDIR=\"$(abs_srcdir)\"
 AM_CFLAGS   = @AM_CFLAGS@ $(WERROR_CFLAGS) $(WARN_CFLAGS)
 AM_LDFLAGS  = @AM_LDFLAGS@
-LDADD       = ../src/libpsl.la
+LDADD       = $(top_builddir)/src/libpsl.la
 
 if !FUZZING
   MAIN = main.c fuzzer.h

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = @AM_CPPFLAGS@ -I$(srcdir) -DSRCDIR=\"$(abs_srcdir)\"
 AM_CFLAGS   = @AM_CFLAGS@ $(WERROR_CFLAGS) $(WARN_CFLAGS)
 AM_LDFLAGS  = @AM_LDFLAGS@
-LDADD       = ../src/libpsl.la $(LIBICU_LIBS) $(LIBIDN_LIBS) $(LIBIDN2_LIBS)
+LDADD       = ../src/libpsl.la
 
 if !FUZZING
   MAIN = main.c fuzzer.h

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = @AM_CPPFLAGS@ -I$(srcdir) -DSRCDIR=\"$(abs_srcdir)\"
 AM_CFLAGS   = @AM_CFLAGS@ $(WERROR_CFLAGS) $(WARN_CFLAGS)
 AM_LDFLAGS  = @AM_LDFLAGS@
-LDADD       = $(top_builddir)/src/libpsl.la
+LDADD       = $(top_builddir)/src/libpsl.la $(runtime_LIBS)
 
 if !FUZZING
   MAIN = main.c fuzzer.h

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -1,7 +1,7 @@
-AM_CFLAGS = $(WERROR_CFLAGS) $(WARN_CFLAGS)
-AM_CPPFLAGS = -I$(top_srcdir)/include -I$(srcdir) -DSRCDIR=\"$(abs_srcdir)\"
-#AM_LDFLAGS = -static
-LDADD = ../src/libpsl.la $(LIBICU_LIBS) $(LIBIDN_LIBS) $(LIBIDN2_LIBS)
+AM_CPPFLAGS = @AM_CPPFLAGS@ -I$(srcdir) -DSRCDIR=\"$(abs_srcdir)\"
+AM_CFLAGS   = @AM_CFLAGS@ $(WERROR_CFLAGS) $(WARN_CFLAGS)
+AM_LDFLAGS  = @AM_LDFLAGS@
+LDADD       = ../src/libpsl.la $(LIBICU_LIBS) $(LIBIDN_LIBS) $(LIBIDN2_LIBS)
 
 if !FUZZING
   MAIN = main.c fuzzer.h
@@ -56,7 +56,7 @@ endif
 if FUZZING
   bin_PROGRAMS = $(PSL_TESTS)
   LDADD += $(LIB_FUZZING_ENGINE)
-  AM_LDFLAGS = -no-install
+  AM_LDFLAGS += -no-install
 else
   AM_CPPFLAGS += -DTEST_RUN
   AM_TESTS_ENVIRONMENT = export VALGRIND_TESTS"=@VALGRIND_TESTS@";

--- a/libpsl.pc.in
+++ b/libpsl.pc.in
@@ -7,6 +7,9 @@ Name: @PACKAGE_NAME@
 Description: Public Suffix List C library.
 Version: @PACKAGE_VERSION@
 URL: @PACKAGE_URL@
-Libs: -L${libdir} -lpsl
-Libs.private: @runtime_LIBS@ @LIBS@
-Cflags: -I${includedir}
+Requires: @libpsl_pc_Requires@
+Requires.private: @libpsl_pc_Requires_private@
+Libs: -L${libdir} -lpsl @libpsl_pc_Libs@
+Libs.private: @libpsl_pc_Libs_private@
+Cflags: -I${includedir} @libpsl_pc_Cflags@
+@libpsl_pc_Cflags_private@

--- a/libpsl.pc.in
+++ b/libpsl.pc.in
@@ -8,5 +8,5 @@ Description: Public Suffix List C library.
 Version: @PACKAGE_VERSION@
 URL: @PACKAGE_URL@
 Libs: -L${libdir} -lpsl
-Libs.private: @LIBS@
+Libs.private: @runtime_LIBS@ @LIBS@
 Cflags: -I${includedir}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,9 @@
 include libpsl-srcs.mk
 
+AM_CPPFLAGS = @AM_CPPFLAGS@
+AM_CFLAGS   = @AM_CFLAGS@
+AM_LDFLAGS  = @AM_LDFLAGS@
+
 # suffixes.c must be created before psl.c is compiled
 BUILT_SOURCES = suffixes_dafsa.h
 
@@ -9,13 +13,12 @@ MAINTAINERCLEANFILES = suffixes_dafsa.h
 
 lib_LTLIBRARIES = libpsl.la
 
-libpsl_la_SOURCES = $(LIBPSL_SRCS)
-libpsl_la_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include -DPSL_DISTFILE=\"$(PSL_DISTFILE)\" \
-  $(CFLAG_VISIBILITY) -DBUILDING_PSL
-libpsl_la_LIBADD = $(LTLIBUNISTRING) $(LTLIBICONV) $(LTLIBINTL) @INTL_MACOSX_LIBS@
-
+libpsl_la_SOURCES  = $(LIBPSL_SRCS)
+libpsl_la_CPPFLAGS = $(AM_CPPFLAGS) -DPSL_DISTFILE=\"$(PSL_DISTFILE)\" -DBUILDING_PSL
+libpsl_la_CFLAGS   = $(AM_CFLAGS) $(CFLAG_VISIBILITY)
 # include ABI version information
-libpsl_la_LDFLAGS = -no-undefined -version-info $(LIBPSL_SO_VERSION)
+libpsl_la_LDFLAGS  = $(AM_LDFLAGS) -no-undefined -version-info $(LIBPSL_SO_VERSION)
+libpsl_la_LIBADD   = $(LTLIBUNISTRING) $(LTLIBICONV) $(LTLIBINTL) @INTL_MACOSX_LIBS@
 
 # Build rule for suffix_dafsa.c
 # PSL_FILE can be set by ./configure --with-psl-file=[PATH]

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,11 +14,11 @@ MAINTAINERCLEANFILES = suffixes_dafsa.h
 lib_LTLIBRARIES = libpsl.la
 
 libpsl_la_SOURCES  = $(LIBPSL_SRCS)
-libpsl_la_CPPFLAGS = $(AM_CPPFLAGS) -DPSL_DISTFILE=\"$(PSL_DISTFILE)\" -DBUILDING_PSL
+libpsl_la_CPPFLAGS = $(AM_CPPFLAGS) $(runtime_CFLAGS) -DPSL_DISTFILE=\"$(PSL_DISTFILE)\" -DBUILDING_PSL
 libpsl_la_CFLAGS   = $(AM_CFLAGS) $(CFLAG_VISIBILITY)
 # include ABI version information
 libpsl_la_LDFLAGS  = $(AM_LDFLAGS) -no-undefined -version-info $(LIBPSL_SO_VERSION)
-libpsl_la_LIBADD   = $(LTLIBUNISTRING) $(LTLIBICONV) $(LTLIBINTL) @INTL_MACOSX_LIBS@
+libpsl_la_LIBADD   = $(runtime_LIBS) $(LTLIBINTL) @INTL_MACOSX_LIBS@
 
 # Build rule for suffix_dafsa.c
 # PSL_FILE can be set by ./configure --with-psl-file=[PATH]

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,8 +2,8 @@ DEFS = @DEFS@ \
        -DSRCDIR=\"$(srcdir)\" \
        -DPSL_FILE=\"$(PSL_FILE)\" \
        -DPSL_TESTFILE=\"$(PSL_TESTFILE)\" \
-       -DPSL_DAFSA=\"$(srcdir)/psl.dafsa\" \
-       -DPSL_ASCII_DAFSA=\"$(srcdir)/psl_ascii.dafsa\"
+       -DPSL_DAFSA=\"@PSL_DAFSA@\" \
+       -DPSL_ASCII_DAFSA=\"@PSL_ASCII_DAFSA@\"
 
 AM_CPPFLAGS = @AM_CPPFLAGS@
 AM_CFLAGS   = @AM_CFLAGS@

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,7 +8,7 @@ DEFS = @DEFS@ \
 AM_CPPFLAGS = @AM_CPPFLAGS@
 AM_CFLAGS   = @AM_CFLAGS@
 AM_LDFLAGS  = @AM_LDFLAGS@ -no-install
-LDADD       = ../src/libpsl.la
+LDADD       = $(top_builddir)/src/libpsl.la
 
 # ./configure'd with '--disable-builtin'
 # Do not call test-is-public-builtin here: it does not make sense.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,9 +4,11 @@ DEFS = @DEFS@ \
        -DPSL_TESTFILE=\"$(PSL_TESTFILE)\" \
        -DPSL_DAFSA=\"$(srcdir)/psl.dafsa\" \
        -DPSL_ASCII_DAFSA=\"$(srcdir)/psl_ascii.dafsa\"
-AM_CPPFLAGS = -I$(top_srcdir)/include
-LDADD = ../src/libpsl.la
-AM_LDFLAGS = -no-install
+
+AM_CPPFLAGS = @AM_CPPFLAGS@
+AM_CFLAGS   = @AM_CFLAGS@
+AM_LDFLAGS  = @AM_LDFLAGS@ -no-install
+LDADD       = ../src/libpsl.la
 
 # ./configure'd with '--disable-builtin'
 # Do not call test-is-public-builtin here: it does not make sense.

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,7 +1,9 @@
 bin_PROGRAMS = psl
 
-AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include
-LDADD = $(top_builddir)/src/libpsl.la
+AM_CPPFLAGS = @AM_CPPFLAGS@
+AM_CFLAGS   = @AM_CFLAGS@
+AM_LDFLAGS  = @AM_LDFLAGS@
+LDADD       = $(top_builddir)/src/libpsl.la
 
 dist_man_MANS = psl.1
 


### PR DESCRIPTION
See #262.

I'm not sure about correctness of "configure.ac: check for Solaris networking libraries early"; I don't have access to Solaris to test it. 

Does libpsl really need those networking libraries? I saw that in meson.build, we add -lws2_32 on Windows, but configure does not do it and Windows builds still work.

I tested these changes with MSVC using my own [build script](https://github.com/maiddaisuki/gnu-libs-with-msvc), including configuration when using static CRT (/MT) and only static dependencies.

I also tested these changes with mingw-w64 (using Msys2) and on my Debian machine. In both cases I tried all three runtimes (libidn2, libidn and libicu) and all configurations worked properly.