### PR TITLE
ci: pin actions to full commit SHAs and add permissions to unit-tests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
 
@@ -39,15 +39,15 @@ jobs:
         run: ./autogen.sh && ./configure --disable-gtk-doc
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@8dca8a82e2fa1a2c8908956f711300f9c4a4f4f6 # v2
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@8dca8a82e2fa1a2c8908956f711300f9c4a4f4f6 # v2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@8dca8a82e2fa1a2c8908956f711300f9c4a4f4f6 # v2
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -18,7 +21,7 @@ jobs:
         runtime: ["libidn", "libidn2", "libicu"]
     steps:
     - name: Check out
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Install dependencies
       run: sudo apt-get install -y autopoint autoconf automake gtk-doc-tools libidn2-dev libunistring-dev libicu-dev libidn-dev
     - name: Test with ${{matrix.runtime}}
@@ -36,7 +39,7 @@ jobs:
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
     steps:
     - name: Check out
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: true
     - name: Install dependencies


### PR DESCRIPTION
**`unit-tests.yml`** — missing `permissions:` block; add `contents: read` + pin `actions/checkout@v4`.

**`codeql.yml`** — pin all three `github/codeql-action` steps and `actions/checkout@v3` to full SHAs.

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v3`/`@v4` | `@f43a0e5f`/`@34e11487` |
| `github/codeql-action/*` | `@v2` | `@8dca8a82` |

Qualifies under the [Google Open Source Patch Rewards Program](https://bughunters.google.com/open-source-security/patch-rewards).