### PR TITLE
Fix typo in configure.ac in PSL_DAFSA assignment

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -583,7 +583,7 @@ PSL_DAFSA=$srcdir/tests/psl.dafsa
 PSL_ASCII_DAFSA=$srcdir/tests/psl_ascii.dafsa
 
 AS_IF([test ! -f "$PSL_DAFSA"], [
-  PSL_DAFSA="\$(top_builddir)/tests/psl.dafsa]")
+  PSL_DAFSA="\$(top_builddir)/tests/psl.dafsa"])
 
 AS_IF([test ! -f "$PSL_ASCII_DAFSA"], [
   PSL_ASCII_DAFSA="\$(top_builddir)/tests/psl_ascii.dafsa"])


### PR DESCRIPTION
Randomly found this issue.

Going to test in-tree / out-of-tree builds more thorough in the next days, there seem to be test issues with paths of dafsa blobs.
