### PR TITLE
Update actions/checkout to v7

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
         runtime: ["libidn", "libidn2", "libicu"]
     steps:
     - name: Check out
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Install dependencies
       run: sudo apt-get install -y autopoint autoconf automake gtk-doc-tools libidn2-dev libunistring-dev libicu-dev libidn-dev
     - name: Test with ${{matrix.runtime}}
@@ -36,7 +36,7 @@ jobs:
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
     steps:
     - name: Check out
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: true
     - name: Install dependencies


### PR DESCRIPTION
Github warning was:
"Node.js 20 is deprecated. The following actions target Node.js 20
 but are being forced to run on Node.js 24: actions/checkout@v4."