### PR TITLE
Support libicucore on Apple OSes

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,17 +10,32 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       max-parallel: 3
       matrix:
-        runtime: ["libidn", "libidn2", "libicu"]
+        include:
+          - runtime: libidn
+            os: ubuntu-latest
+          - runtime: libidn2
+            os: ubuntu-latest
+          - runtime: libicu
+            os: ubuntu-latest
+          - runtime: libicucore
+            os: macos-latest
     steps:
     - name: Check out
       uses: actions/checkout@v7
     - name: Install dependencies
-      run: sudo apt-get install -y autopoint autoconf automake gtk-doc-tools libidn2-dev libunistring-dev libicu-dev libidn-dev lzip
+      run: |
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          brew install autoconf automake gtk-doc libtool lzip
+          echo "am_cv_func_iconv_works=yes" >> $GITHUB_ENV # Use system libiconv on macOS
+          echo "XML_CATALOG_FILES=$(brew --prefix)/etc/xml/catalog" >> $GITHUB_ENV
+        else
+          sudo apt-get install -y autopoint autoconf automake gtk-doc-tools libidn2-dev libunistring-dev libicu-dev libidn-dev lzip
+        fi
     - name: Test with ${{matrix.runtime}}
       run: |
           ./autogen.sh

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Libpsl...
 - finds the shortest private part of a given domain
 - works with international domains (UTF-8 and IDNA2008 Punycode)
 - is thread-safe
-- handles IDNA2008 UTS#46 (if either libidn2 or libicu is available)
+- handles IDNA2008 UTS#46 (if libidn2, libicu or libicucore is available)
 
 Find more information about the Public Suffix List [here](https://publicsuffix.org/).
 
@@ -125,7 +125,7 @@ Prerequisites:
   - basic C development tools (compiler, linker, make)
   - autoconf, autoconf-archive, autopoint, automake, autotools
   - libtool, gettext, pkg-config
-  - development files for either libidn2, libicu or libidn (the latter only offers IDNA2003)
+  - development files for either libidn2, libicu, libicucore or libidn (the latter only offers IDNA2003)
   - for building docs: gtk-doc-tools (gtkdocize)
 
 		./autogen.sh

--- a/configure.ac
+++ b/configure.ac
@@ -153,6 +153,7 @@ AC_ARG_ENABLE(runtime,
       Specify the IDNA library used for libpsl run-time conversions:
         libidn2 [[default]]: IDNA2008 library (also needs libunistring)
         libicu:            IDNA2008 UTS#46 library
+        libicucore:        IDNA2008 UTS#46 library shipped with Apple OSes
         libidn:            IDNA2003 library (also needs libunistring)
   --disable-runtime        Do not link runtime IDNA functionality
   ], [
@@ -162,6 +163,9 @@ AC_ARG_ENABLE(runtime,
     elif test "$enableval" = "libicu"; then
       enable_runtime=libicu
       AC_DEFINE([WITH_LIBICU], [1], [generate PSL data using libicu])
+    elif test "$enableval" = "libicucore"; then
+      enable_runtime=libicucore
+      AC_DEFINE([WITH_LIBICUCORE], [1], [generate PSL data using libicucore])
     elif test "$enableval" = "libidn"; then
       enable_runtime=libidn
       AC_DEFINE([WITH_LIBIDN], [1], [generate PSL data using libidn])
@@ -238,6 +242,31 @@ runtime_LIBS=
 
 AC_SUBST([runtime_CFLAGS])
 AC_SUBST([runtime_LIBS])
+
+dnl Check for libicucore
+if test "$enable_runtime" = "libicucore" || { test "$host_vendor" = "apple" -a "$enable_runtime" = "auto"; }; then
+  HAVE_LIBICUCORE=no
+
+  # Check if we can link against libicucore
+  AC_CHECK_LIB(icucore, uidna_openUTS46, [
+    AC_CHECK_HEADER(unicode/uidna.h, [
+      HAVE_LIBICUCORE=yes
+    ])
+  ])
+
+  if test "x$HAVE_LIBICUCORE" = "xyes"; then
+    runtime_LIBS="-licucore"
+
+    if test "$enable_runtime" = "auto"; then
+      enable_runtime=libicucore
+      AC_DEFINE([WITH_LIBICUCORE], [1], [generate PSL data using libicucore])
+    fi
+  else
+    if test "$enable_runtime" = "libicucore"; then
+      AC_MSG_ERROR([You requested libicucore but it is not available or usable.])
+    fi
+  fi
+fi
 
 dnl Check for libidn2
 if test "$enable_runtime" = "libidn2" -o "$enable_runtime" = "auto"; then
@@ -489,30 +518,33 @@ if test "$enable_runtime" = "auto"; then
   enable_runtime=no
 fi
 
-dnl If we use libidn or libidn2, we also need libiconv and libunistring
-if test "x$enable_runtime" = "xlibidn2" -o "x$enable_runtime" = "xlibidn"; then
+dnl If we use libidn or libidn2, we also need libiconv and libunistring. libicucore also needs iconv
+if test "x$enable_runtime" = "xlibidn2" -o "x$enable_runtime" = "xlibidn" -o "x$enable_runtime" = "xlibicucore"; then
   __save_LIBS=$LIBS
 
   LIBS=$LIBICONV
   AC_LINK_IFELSE([
     AC_LANG_PROGRAM([#include <iconv.h>], [iconv_open ("", "");])
   ], [:], [
-    AC_MSG_ERROR([You requested libidn2|libidn but libiconv is not installed.])
+    AC_MSG_ERROR([You requested libidn2|libidn|libicucore but libiconv is not installed.])
   ])
   LIBS=$__save_LIBS
+  runtime_LIBS="$runtime_LIBS $LTLIBICONV"
 
-  LIBS=$LIBUNISTRING
-  AC_LINK_IFELSE([
-    AC_LANG_PROGRAM([char u8_tolower (void);], [u8_tolower ();])
-  ], [:], [
-    AC_MSG_ERROR([You requested libidn2|libidn but libunistring is not installed.])
-  ])
-  LIBS=$__save_LIBS
-
-  runtime_LIBS="$runtime_LIBS $LTLIBUNISTRING $LTLIBICONV"
+  if test "x$enable_runtime" != "xlibicucore"; then
+    LIBS=$LIBUNISTRING
+    AC_LINK_IFELSE([
+      AC_LANG_PROGRAM([char u8_tolower (void);], [u8_tolower ();])
+    ], [:], [
+      AC_MSG_ERROR([You requested libidn2|libidn but libunistring is not installed.])
+    ])
+    LIBS=$__save_LIBS
+    runtime_LIBS="$runtime_LIBS $LTLIBUNISTRING"
+  fi
 fi
 
 AM_CONDITIONAL([WITH_LIBICU], test "x$enable_runtime" = "xlibicu")
+AM_CONDITIONAL([WITH_LIBICUCORE], test "x$enable_runtime" = "xlibicucore")
 AM_CONDITIONAL([WITH_LIBIDN2], test "x$enable_runtime" = "xlibidn2")
 AM_CONDITIONAL([WITH_LIBIDN], test "x$enable_runtime" = "xlibidn")
 AM_CONDITIONAL([ENABLE_BUILTIN], test "x$enable_builtin" = "xyes")
@@ -538,6 +570,8 @@ elif test "$enable_runtime" = libicu; then
   else
     libpsl_pc_Libs_private="$LIBICU_LIBS $LIBS"
   fi
+elif test "$enable_runtime" = libicucore; then
+  libpsl_pc_Libs_private="-licucore $LTLIBICONV $LIBS"
 fi
 
 dnl On Windows we use pkgconf-specific Cflags.private to pass -DPSL_STATIC

--- a/meson.build
+++ b/meson.build
@@ -14,12 +14,24 @@ buildtype = get_option('buildtype')
 notfound = dependency('', required : false)
 libidn2_dep = notfound
 libicu_dep = notfound
+libicucore_dep = notfound
 libidn_dep = notfound
 libunistring = notfound
 networking_deps = notfound
 libiconv_dep = notfound
 
 link_language = 'c'
+
+if enable_runtime == 'libicucore' or (host_machine.system() == 'darwin' and enable_runtime == 'auto')
+  libicucore_dep = cc.find_library('icucore', has_headers : ['unicode/uidna.h'], required : false)
+  if libicucore_dep.found()
+    if enable_runtime == 'auto'
+      enable_runtime = 'libicucore'
+    endif
+  elif enable_runtime == 'libicucore'
+    error('You requested libicucore but it is not available.')
+  endif
+endif
 
 # FIXME: Cleanup this when Meson gets 'feature-combo':
 # https://github.com/mesonbuild/meson/issues/4566
@@ -71,9 +83,11 @@ if ['libidn', 'auto'].contains(enable_runtime)
   endif
 endif
 
-if libidn2_dep.found() or libidn_dep.found()
-  # Check for libunistring, we need it for psl_str_to_utf8lower()
-  libunistring = cc.find_library('unistring')
+if libidn2_dep.found() or libidn_dep.found() or libicucore_dep.found()
+  if not libicucore_dep.found()
+    # Check for libunistring, we need it for psl_str_to_utf8lower()
+    libunistring = cc.find_library('unistring')
+  endif
   libiconv_dep = dependency('iconv')
 endif
 
@@ -89,6 +103,7 @@ config = configuration_data()
 config.set_quoted('PACKAGE_VERSION', meson.project_version())
 config.set('WITH_LIBIDN2', enable_runtime == 'libidn2')
 config.set('WITH_LIBICU', enable_runtime == 'libicu')
+config.set('WITH_LIBICUCORE', enable_runtime == 'libicucore')
 config.set('WITH_LIBIDN', enable_runtime == 'libidn')
 config.set('ENABLE_BUILTIN', enable_builtin)
 config.set('HAVE_UNISTD_H', cc.check_header('unistd.h'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,5 @@
 option('runtime', type : 'combo',
-  choices : ['libidn2', 'libicu', 'libidn', 'no', 'auto'], value : 'auto',
+  choices : ['libidn2', 'libicu', 'libicucore', 'libidn', 'no', 'auto'], value : 'auto',
   description : 'Specify the IDNA library used for libpsl run-time conversions')
 
 option('builtin', type : 'boolean',

--- a/src/meson.build
+++ b/src/meson.build
@@ -37,7 +37,7 @@ endif
 libpsl = library('psl', sources, suffixes_dafsa_h,
   include_directories : [configinc, includedir],
   c_args : cargs,
-  dependencies : [libidn2_dep, libidn_dep, libicu_dep, libunistring, networking_deps, libiconv_dep],
+  dependencies : [libidn2_dep, libidn_dep, libicu_dep, libicucore_dep, libunistring, networking_deps, libiconv_dep],
   gnu_symbol_visibility: 'hidden',
   version: library_version,
   install: true,

--- a/src/psl.c
+++ b/src/psl.c
@@ -99,6 +99,11 @@ typedef SSIZE_T ssize_t;
 #	include <unicode/ustring.h>
 #	include <unicode/uidna.h>
 #	include <unicode/ucnv.h>
+#elif defined(WITH_LIBICUCORE)
+#	include <iconv.h>
+#	include <unicode/uversion.h>
+#	include <unicode/ustring.h>
+#	include <unicode/uidna.h>
 #elif defined(WITH_LIBIDN2)
 #	include <iconv.h>
 #	include <idn2.h>
@@ -349,7 +354,7 @@ static char *psl_strdup(const char *s)
 	return strcpy(p, s);
 }
 
-#if !defined(WITH_LIBIDN) && !defined(WITH_LIBIDN2) && !defined(WITH_LIBICU)
+#if !defined(WITH_LIBIDN) && !defined(WITH_LIBIDN2) && !defined(WITH_LIBICU) && !defined(WITH_LIBICUCORE)
 /*
  * When configured without runtime IDNA support (./configure --disable-runtime), we need a pure ASCII
  * representation of non-ASCII characters in labels as found in UTF-8 domain names.
@@ -683,7 +688,7 @@ typedef void *psl_idna_t;
 
 static psl_idna_t *psl_idna_open(void)
 {
-#if defined(WITH_LIBICU)
+#if defined(WITH_LIBICU) || defined(WITH_LIBICUCORE)
 	UErrorCode status = 0;
 	return (void *)uidna_openUTS46(UIDNA_USE_STD3_RULES | UIDNA_NONTRANSITIONAL_TO_ASCII, &status);
 #endif
@@ -694,7 +699,7 @@ static void psl_idna_close(psl_idna_t *idna)
 {
 	(void) idna;
 
-#if defined(WITH_LIBICU)
+#if defined(WITH_LIBICU) || defined(WITH_LIBICUCORE)
 	if (idna)
 		uidna_close((UIDNA *)idna);
 #endif
@@ -704,7 +709,7 @@ static int psl_idna_toASCII(psl_idna_t *idna, const char *utf8, char **ascii)
 {
 	int ret = -1;
 
-#if defined(WITH_LIBICU)
+#if defined(WITH_LIBICU) || defined(WITH_LIBICUCORE)
 	(void) idna;
 
 	/* IDNA2008 UTS#46 punycode conversion */
@@ -1575,6 +1580,8 @@ const char *psl_get_version(void)
 {
 #ifdef WITH_LIBICU
 	return PACKAGE_VERSION " (+libicu/" U_ICU_VERSION ")";
+#elif defined(WITH_LIBICUCORE)
+	return PACKAGE_VERSION " (+libicucore/" U_ICU_VERSION ")";
 #elif defined(WITH_LIBIDN2)
 	return PACKAGE_VERSION " (+libidn2/" IDN2_VERSION ")";
 #elif defined(WITH_LIBIDN)
@@ -1780,13 +1787,91 @@ void psl_free_string(char *str)
 		free(str);
 }
 
-#if defined(WITH_LIBIDN2) || defined(WITH_LIBIDN)
+#if defined(WITH_LIBIDN2) || defined(WITH_LIBIDN) || defined(WITH_LIBICUCORE)
 /* Avoid using strcasecmp() or _stricmp() */
 static int isUTF8(const char *s) {
 	return (s[0] == 'u' || s[0] == 'U')
 		&& (s[1] == 't' || s[1] == 'T')
 		&& (s[2] == 'f' || s[2] == 'F')
 		&& s[3] == '-' && s[4] == 0;
+}
+
+static char *idn_u8_tolower(const char *buf, size_t len, const char *locale)
+{
+#if defined(WITH_LIBICUCORE)
+	if (len > INT_MAX)
+		return NULL;
+
+	int32_t src_len = (int32_t)len;
+	if (src_len > 0 && buf[src_len - 1] == 0)
+		src_len--;
+
+	UErrorCode status = U_ZERO_ERROR;
+	int32_t utf16_src_len;
+	u_strFromUTF8(NULL, 0, &utf16_src_len, buf, src_len, &status);
+	if (U_FAILURE(status) && status != U_BUFFER_OVERFLOW_ERROR)
+		return NULL;
+
+	UChar *utf16_src = malloc((size_t)utf16_src_len * sizeof(UChar));
+	if (!utf16_src)
+		return NULL;
+
+	status = U_ZERO_ERROR;
+	u_strFromUTF8(utf16_src, utf16_src_len, NULL, buf, src_len, &status);
+	if (U_FAILURE(status)) {
+		free(utf16_src);
+		return NULL;
+	}
+
+	status = U_ZERO_ERROR;
+	int32_t utf16_lower_len = u_strToLower(NULL, 0, utf16_src, utf16_src_len, locale, &status);
+	if (U_FAILURE(status) && status != U_BUFFER_OVERFLOW_ERROR) {
+		free(utf16_src);
+		return NULL;
+	}
+
+	UChar *utf16_lower = malloc((size_t)utf16_lower_len * sizeof(UChar));
+	if (!utf16_lower) {
+		free(utf16_src);
+		return NULL;
+	}
+
+	status = U_ZERO_ERROR;
+	u_strToLower(utf16_lower, utf16_lower_len, utf16_src, utf16_src_len, locale, &status);
+	free(utf16_src);
+	if (U_FAILURE(status)) {
+		free(utf16_lower);
+		return NULL;
+	}
+
+	status = U_ZERO_ERROR;
+	int32_t utf8_lower_len;
+	u_strToUTF8(NULL, 0, &utf8_lower_len, utf16_lower, utf16_lower_len, &status);
+	if (U_FAILURE(status) && status != U_BUFFER_OVERFLOW_ERROR) {
+		free(utf16_lower);
+		return NULL;
+	}
+
+	char *result = malloc((size_t)utf8_lower_len + 1);
+	if (!result) {
+		free(utf16_lower);
+		return NULL;
+	}
+
+	status = U_ZERO_ERROR;
+	u_strToUTF8(result, utf8_lower_len + 1, NULL, utf16_lower, utf16_lower_len, &status);
+	free(utf16_lower);
+	if (U_FAILURE(status)) {
+		free(result);
+		result = NULL;
+	}
+
+	return result;
+#else
+	(void) locale;
+
+	return (char *)u8_tolower((uint8_t *)buf, len, 0, UNINORM_NFKC, NULL, &len);
+#endif
 }
 #endif
 
@@ -1920,7 +2005,7 @@ out:
 		free(utf8_lower);
 
 	} while (0);
-#elif defined(WITH_LIBIDN2) || defined(WITH_LIBIDN)
+#elif defined(WITH_LIBIDN2) || defined(WITH_LIBIDN) || defined(WITH_LIBICUCORE)
 	do {
 		/* find out local charset encoding */
 		if (!encoding) {
@@ -1956,7 +2041,7 @@ out:
 					 * and thus in len. */
 					size_t len = dst_len - dst_len_tmp;
 
-					if ((tmp = (char *)u8_tolower((uint8_t *)dst, len, 0, UNINORM_NFKC, NULL, &len))) {
+					if ((tmp = idn_u8_tolower(dst, len, locale))) {
 						ret = PSL_SUCCESS;
 						if (lower) {
 							*lower = tmp;
@@ -1980,16 +2065,16 @@ out:
 			}
 		} else {
 			/* we need a conversion to lowercase */
-			uint8_t *tmp;
+			char *tmp;
 
 			/* start size for u8_tolower internal memory allocation.
 			 * u8_tolower() does not terminate the result string, so include terminating 0 byte in len. */
-			size_t len = u8_strlen((uint8_t *)str) + 1;
+			size_t len = strlen(str) + 1;
 
-			if ((tmp = u8_tolower((uint8_t *)str, len, 0, UNINORM_NFKC, NULL, &len))) {
+			if ((tmp = idn_u8_tolower(str, len, locale))) {
 				ret = PSL_SUCCESS;
 				if (lower) {
-					*lower = (char*)tmp;
+					*lower = tmp;
 					tmp = NULL;
 				} else
 					free(tmp);


### PR DESCRIPTION
Apple OSes (macOS etc) ship with a libicucore with the system. For the purposes of libpsl, this is basically the same as regular ICU except that it doesn't have `ucnv` and requires a different `-l` flag.

This PR adds support for libicucore by using the ICU paths, except for `psl_str_to_utf8lower` where it uses the iconv path but with ICU calls instead of libunistring.

The benefit here is that on macOS, `libpsl` now no longer requires any external dependencies beyond what ships with the OS.