### PR TITLE
Fix handling of dafsa tests with in-tree builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -579,13 +579,13 @@ fi
 dnl Normally, tests/psl.dafsa and tests/psl_ascii.dafsa are distributed with
 dnl source code. When doing out-of-tree build from git checkout, they will be
 dnl generated in builddir. Make sure we support both cases.
-PSL_DAFSA=$srcdir/tests/psl.dafsa
-PSL_ASCII_DAFSA=$srcdir/tests/psl_ascii.dafsa
+PSL_DAFSA="\$(top_srcdir)/tests/psl.dafsa"
+PSL_ASCII_DAFSA="\$(top_srcdir)/tests/psl_ascii.dafsa"
 
-AS_IF([test ! -f "$PSL_DAFSA"], [
+AS_IF([test ! -f "$srcdir/tests/psl.dafsa"], [
   PSL_DAFSA="\$(top_builddir)/tests/psl.dafsa"])
 
-AS_IF([test ! -f "$PSL_ASCII_DAFSA"], [
+AS_IF([test ! -f "$srcdir/tests/psl_ascii.dafsa"], [
   PSL_ASCII_DAFSA="\$(top_builddir)/tests/psl_ascii.dafsa"])
 
 AC_SUBST([PSL_DAFSA])


### PR DESCRIPTION
`$srcdir` can be a relative directory which is not safe to encode into the makefile given it runs tests under a subdirectory. Instead encode `$(top_srcdir)` in a similar fashion we do to `$(top_builddir)`.