### PR TITLE
Update .gitignore for newer gettext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ po/Rules-quot
 po/boldquot.sed
 po/en@boldquot.header
 po/en@quot.header
+po/fetch-po
+po/insert-header.sed
 po/insert-header.sin
 po/psl.pot
 po/libpsl.pot


### PR DESCRIPTION
`insert-header.sed` was added in gettext 0.23 and fetch-po was added in gettext 1.0.

We could probably do this in a better way (e.g. invert it so it ignores everything but the two files checked in), but this PR is the minimum required change for building with newer gettext.