### PR TITLE
Using libidn as runtime requires explicit config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -442,7 +442,7 @@ if test "$enable_runtime" = "libicu" -o "$enable_runtime" = "auto"; then
 fi
 
 dnl Checl for libidn
-if test "$enable_runtime" = "libidn" -o "$enable_runtime" = "auto"; then
+if test "$enable_runtime" = "libidn"; then
   HAVE_LIBIDN=no
 
   # Save CFLAGS and LIBS so we can restore them later
@@ -502,11 +502,6 @@ if test "$enable_runtime" = "libidn" -o "$enable_runtime" = "auto"; then
   if test "x$HAVE_LIBIDN" = "xyes"; then
     runtime_CFLAGS=$LIBIDN_CFLAGS
     runtime_LIBS=$LIBIDN_LIBS
-
-    if test "$enable_runtime" = "auto"; then
-      enable_runtime=libidn
-      AC_DEFINE([WITH_LIBIDN], [1], [generate PSL data using libidn])
-    fi
   else
     if test "$enable_runtime" = "libidn"; then
       AC_MSG_ERROR([You requested libidn but it is not installed or usable.])


### PR DESCRIPTION
Libidn turned out to be problematic with latest PSL (see #277).
Before we drop support, this PR requires configuring libidn as runtime library explicitly.