### PR TITLE
Always add default test files to the tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,7 @@ EXTRA_DIST = build-aux/config.rpath LICENSE meson.build  meson_options.txt
 dist-hook:
 	mkdir -p $(distdir)/list/tests
 	cp -p $(PSL_FILE) $(distdir)/list
+	cp -p $(PSL_DEFAULT_TESTFILES) $(distdir)/list/tests
 	cp -p $(PSL_TESTFILE) $(distdir)/list/tests
 
 clean-local:

--- a/configure.ac
+++ b/configure.ac
@@ -619,6 +619,8 @@ AC_ARG_WITH([psl-testfile],
   [PSL_TESTFILE=$withval],
   [PSL_TESTFILE="\$(top_srcdir)/list/tests/tests.txt"])
 AC_SUBST([PSL_TESTFILE])
+AC_SUBST([PSL_DEFAULT_TESTFILES],
+  ["\$(top_srcdir)/list/tests/test_psl.txt \$(top_srcdir)/list/tests/tests.txt"])
 
 AC_CHECK_FUNCS([clock_gettime fmemopen nl_langinfo])
 AC_CHECK_DECLS([localtime_r])


### PR DESCRIPTION
Currently, `make dist` only adds the test file specified by `PSL_TESTFILE`. This patch unconditionally adds both tests from list/tests, while `PSL_TESTFILE` can still be set to add or overwrite a desired test file.