### PR TITLE
meson: also rename cdata to _cdata in docs/libpsl/meson.build

### DIFF
--- a/docs/libpsl/meson.build
+++ b/docs/libpsl/meson.build
@@ -4,7 +4,7 @@ if get_option('docs')
   configure_file(
     input : 'version.xml.in',
     output : 'version.xml',
-    configuration : cdata)
+    configuration : _cdata)
 
   docs = gnome.gtkdoc('libpsl',
     main_sgml: 'libpsl-docs.sgml',


### PR DESCRIPTION
Otherwise, when building the docs using meson, the build will break with `../docs/libpsl/meson.build:7:20: ERROR: Unknown variable "cdata".` now that `cdata`  has been renamed to `_cdata` in da5479661839e25783ee482e0180efc3d28f2428.