### PR TITLE
Allow explicitly disabling fuzzing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,9 +94,10 @@ PKG_PROG_PKG_CONFIG
 
 AC_ARG_ENABLE([fuzzing],
   [AS_HELP_STRING([--enable-fuzzing], [Turn on fuzzing build (for developers)])], [
-    enable_fuzzing=yes
-    AC_SUBST([LIB_FUZZING_ENGINE])
-    AC_DEFINE([FUZZING], 1, [Define to 1 if this is a fuzzing build])
+    AS_IF([test "$enable_fuzzing" = yes], [
+      AC_SUBST([LIB_FUZZING_ENGINE])
+      AC_DEFINE([FUZZING], 1, [Define to 1 if this is a fuzzing build])
+    ])
   ], [enable_fuzzing=no; LIB_FUZZING_ENGINE=""])
 AM_CONDITIONAL([FUZZING], [test "$enable_fuzzing" = "yes"])
 


### PR DESCRIPTION
Using `--disable-fuzzing` explicitly to create fixed flag builds currently turns on fuzzing since configure.ac manually overrides the flag.
Since the enable-fuzzing flag is set by configure it should confirm its state is true. This is already done for other flags but not for the fuzzing flag.

This PR corrects this so `--disable-fuzzing` works as expected.

Before:
```
./configure --disable-fuzzing
cat config.log | grep -i "fuzzing build"
> Fuzzing build:     yes,
```
After:
```
./configure --disable-fuzzing
cat config.log | grep -i "fuzzing build"
> Fuzzing build:     no,
```