### PR TITLE
Use python3 in the psl-make-dafsa shebang

### DIFF
--- a/src/psl-make-dafsa
+++ b/src/psl-make-dafsa
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE.chromium file.


### PR DESCRIPTION
The script is run through `#!/usr/bin/env python`, which fails on systems that
no longer ship a `python` binary. Since Python 2 reached end of life most
distributions provide only `python3`, and PEP 394 recommends that scripts
requiring Python 3 spell it out.

The script itself is already Python 3 (it is invoked as `python3` by
src/meson.build), so this only fixes running it directly.
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
