### PR TITLE
meson: Drop Python dependency for tarball builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -143,7 +143,11 @@ if psl_test_file == ''
   psl_test_file = join_paths(meson.current_source_dir(), 'list', 'tests', 'tests.txt')
 endif
 
-python = find_program('python3')
+python = find_program('python3', required : false)
+if not python.found()
+  python = find_program('python', required : false)
+endif
+
 pkgconfig = import('pkgconfig')
 
 if cc.get_id() == 'msvc'

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,9 +1,21 @@
 psl_make_dafsa = files('psl-make-dafsa')
 
-suffixes_dafsa_h = custom_target('suffixes_dafsa.h',
-  input : psl_file,
-  output : 'suffixes_dafsa.h',
-  command : [python, psl_make_dafsa, '--output-format=cxx+', '@INPUT@', '@OUTPUT@'])
+fs = import('fs')
+suffixes_dafsa_h_src = join_paths(meson.current_source_dir(), 'suffixes_dafsa.h')
+has_suffixes_dafsa_h = fs.exists(suffixes_dafsa_h_src)
+
+if has_suffixes_dafsa_h
+  suffixes_dafsa_h = suffixes_dafsa_h_src
+else
+  if not python.found()
+    error('Python is required to build suffixes_dafsa.h. Install python or provide suffixes_dafsa.h in src/')
+  endif
+
+  suffixes_dafsa_h = custom_target('suffixes_dafsa.h',
+    input : psl_file,
+    output : 'suffixes_dafsa.h',
+    command : [python, psl_make_dafsa, '--output-format=cxx+', '@INPUT@', '@OUTPUT@'])
+endif
 
 sources = [
   'lookup_string_in_fixed_set.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,23 +1,45 @@
-psl_dafsa = custom_target('psl.dafsa',
-  input : psl_file,
-  output : 'psl.dafsa',
-  build_by_default: false,
-  command : [python, psl_make_dafsa, '--output-format=binary', '@INPUT@', '@OUTPUT@'])
+fs = import('fs')
 
-psl_ascii_dafsa = custom_target('psl_ascii.dafsa',
-  input : psl_file,
-  output : 'psl_ascii.dafsa',
-  build_by_default: false,
-  command : [python, psl_make_dafsa, '--output-format=binary', '--encoding=ascii', '@INPUT@', '@OUTPUT@'])
+psl_dafsa_src = join_paths(meson.current_source_dir(), 'psl.dafsa')
+psl_ascii_dafsa_src = join_paths(meson.current_source_dir(), 'psl_ascii.dafsa')
+has_dafsa_files = fs.exists(psl_dafsa_src) and fs.exists(psl_ascii_dafsa_src)
 
-fsmod = import('fs')
+if has_dafsa_files
+  psl_dafsa = psl_dafsa_src
+  psl_ascii_dafsa = psl_ascii_dafsa_src
+else
+  if not python.found()
+    error('Python is required to build DAFSA files. Install python or provide psl.dafsa and psl_ascii.dafsa in tests/')
+  endif
+
+  psl_dafsa = custom_target('psl.dafsa',
+    input : psl_file,
+    output : 'psl.dafsa',
+    build_by_default: false,
+    command : [python, psl_make_dafsa, '--output-format=binary', '@INPUT@', '@OUTPUT@'])
+
+  psl_ascii_dafsa = custom_target('psl_ascii.dafsa',
+    input : psl_file,
+    output : 'psl_ascii.dafsa',
+    build_by_default: false,
+    command : [python, psl_make_dafsa, '--output-format=binary', '--encoding=ascii', '@INPUT@', '@OUTPUT@'])
+endif
+
+if has_dafsa_files
+  psl_dafsa_path = fs.as_posix(psl_dafsa_src)
+  psl_ascii_dafsa_path = fs.as_posix(psl_ascii_dafsa_src)
+else
+  psl_dafsa_path = fs.as_posix(psl_dafsa.full_path())
+  psl_ascii_dafsa_path = fs.as_posix(psl_ascii_dafsa.full_path())
+endif
+
 tests_cargs = [
   '-DHAVE_CONFIG_H',
   '-DSRCDIR="@0@"'.format(meson.current_source_dir()),
   '-DPSL_FILE="@0@"'.format(psl_file),
   '-DPSL_TESTFILE="@0@"'.format(psl_test_file),
-  '-DPSL_DAFSA="@0@"'.format(fsmod.as_posix(psl_dafsa.full_path())),
-  '-DPSL_ASCII_DAFSA="@0@"'.format(fsmod.as_posix(psl_ascii_dafsa.full_path())),
+  '-DPSL_DAFSA="@0@"'.format(psl_dafsa_path),
+  '-DPSL_ASCII_DAFSA="@0@"'.format(psl_ascii_dafsa_path),
 ]
 
 tests = [
@@ -42,5 +64,9 @@ foreach test_name : tests
     include_directories : configinc,
     link_language : link_language,
     dependencies : [libpsl_dep, networking_deps])
-  test(test_name, exe, depends : [psl_dafsa, psl_ascii_dafsa])
+  if not has_dafsa_files
+    test(test_name, exe, depends : [psl_dafsa, psl_ascii_dafsa])
+  else
+    test(test_name, exe)
+  endif
 endforeach


### PR DESCRIPTION
Same as for autotools build: Meson doesn't need Python when building from tarball.

Additional: The PR also falls back to `python` if `python3` wasn't found (for the case where building the DAFSA files is needed).
